### PR TITLE
Drop composer autoload outside tests

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -63,8 +63,6 @@ define(
     GLPI_PLUGIN_DOC_DIR . "/glpiinventory/xml/"
 );
 
-include_once GLPI_ROOT . '/plugins/glpiinventory/vendor/autoload.php';
-
 /**
  * Check if the script name finish by
  *


### PR DESCRIPTION
There are only dev dependencies, this autoload file should not be included from setup.php (and its path was not compatible with marketplace installation).