### PR TITLE
fix(right): new rights based on creation (without itemtype)

### DIFF
--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -365,12 +365,12 @@ class PluginGlpiinventoryProfile extends Profile
           /*['itemtype'  => 'PluginGlpiinventoryConfigSecurity',
                 'label'     => __('SNMP credentials', 'glpiinventory'),
                 'field'     => 'plugin_glpiinventory_configsecurity'],*/
-          /*['itemtype'  => 'PluginGlpiinventoryNetworkEquipment',
+          ['rights'    => [CREATE => __('Create')],
                 'label'     => __('Network equipment SNMP', 'glpiinventory'),
-                'field'     => 'plugin_glpiinventory_networkequipment'],*/
-          /*['itemtype'  => 'PluginGlpiinventoryPrinter',
+                'field'     => 'plugin_glpiinventory_networkequipment'],
+          ['rights'    => [CREATE => __('Create')],
                 'label'     => __('Printer SNMP', 'glpiinventory'),
-                'field'     => 'plugin_glpiinventory_printer'],*/
+                'field'     => 'plugin_glpiinventory_printer'],
           /*['itemtype'  => 'PluginGlpiinventoryUnmanaged',
                 'label'     => __('Unmanaged devices', 'glpiinventory'),
                 'field'     => 'plugin_glpiinventory_unmanaged'],*/

--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -573,8 +573,8 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
 
         $modules_methods = PluginGlpiinventoryStaticmisc::getModulesMethods();
         if (
-            !Session::haveRight('plugin_glpiinventory_networkequipment', READ)
-              and !Session::haveRight('plugin_glpiinventory_printer', READ)
+            !Session::haveRight('plugin_glpiinventory_networkequipment', CREATE)
+              and !Session::haveRight('plugin_glpiinventory_printer', CREATE)
         ) {
             if (isset($modules_methods['networkdiscovery'])) {
                 unset($modules_methods['networkdiscovery']);


### PR DESCRIPTION
Old rights are based on itemtype (```PluginGlpiinventoryPrinter``` and ```PluginGlpiinventoryNetworkEquipement```) that no longer exist
```php
          ['itemtype'  => 'PluginGlpiinventoryNetworkEquipment',
                'label'     => __('Network equipment SNMP', 'glpiinventory'),
                'field'     => 'plugin_glpiinventory_networkequipment'],
          ['itemtype'  => 'PluginGlpiinventoryPrinter',
                'label'     => __('Printer SNMP', 'glpiinventory'),
                'field'     => 'plugin_glpiinventory_printer'],
```
Move to ```CREATE``` right

fix https://github.com/glpi-project/glpi-inventory-plugin/issues/14