### PR TITLE
Add handled tasks hooks support

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -1016,3 +1016,45 @@ function plugin_glpiinventory_network_inventory($params)
 
     return $params;
 }
+
+function plugin_glpiinventory_handle_common_handle_task($task, array $params)
+{
+    $a_plugin = plugin_version_glpiinventory();
+    $params['options']['response'][$task] = [
+        'version' => PLUGIN_GLPIINVENTORY_VERSION,
+        'server' => $a_plugin['shortname']
+    ];
+
+    return $params;
+}
+
+function plugin_glpiinventory_handle_netdiscovery_task(array $params)
+{
+    return plugin_glpiinventory_handle_common_handle_task('netdiscovery', $params);
+}
+
+function plugin_glpiinventory_handle_netinventory_task(array $params)
+{
+    return plugin_glpiinventory_handle_common_handle_task('netinventory', $params);
+}
+
+
+function plugin_glpiinventory_handle_esx_task(array $params)
+{
+    return plugin_glpiinventory_handle_common_handle_task('esx', $params);
+}
+
+function plugin_glpiinventory_handle_collect_task(array $params)
+{
+    return plugin_glpiinventory_handle_common_handle_task('collect', $params);
+}
+
+function plugin_glpiinventory_handle_deploy_task(array $params)
+{
+    return plugin_glpiinventory_handle_common_handle_task('deploy', $params);
+}
+
+function plugin_glpiinventory_handle_wakeonlan_task(array $params)
+{
+    return plugin_glpiinventory_handle_common_handle_task('wakeonlan', $params);
+}

--- a/setup.php
+++ b/setup.php
@@ -385,6 +385,14 @@ function plugin_init_glpiinventory()
     $PLUGIN_HOOKS[Hooks::PROLOG_RESPONSE]['glpiinventory'] = 'plugin_glpiinventory_prolog_response';
     $PLUGIN_HOOKS[Hooks::NETWORK_DISCOVERY]['glpiinventory'] = 'plugin_glpiinventory_network_discovery';
     $PLUGIN_HOOKS[Hooks::NETWORK_INVENTORY]['glpiinventory'] = 'plugin_glpiinventory_network_inventory';
+
+   // Support JSON protocol CONTACT requests from agents
+    $PLUGIN_HOOKS[Hooks::HANDLE_NETDISCOVERY_TASK]['glpiinventory'] = 'plugin_glpiinventory_handle_netdiscovery_task';
+    $PLUGIN_HOOKS[Hooks::HANDLE_NETINVENTORY_TASK]['glpiinventory'] = 'plugin_glpiinventory_handle_netinventory_task';
+    $PLUGIN_HOOKS[Hooks::HANDLE_ESX_TASK]['glpiinventory'] = 'plugin_glpiinventory_handle_esx_task';
+    $PLUGIN_HOOKS[Hooks::HANDLE_COLLECT_TASK]['glpiinventory'] = 'plugin_glpiinventory_handle_collect_task';
+    $PLUGIN_HOOKS[Hooks::HANDLE_DEPLOY_TASK]['glpiinventory'] = 'plugin_glpiinventory_handle_deploy_task';
+    $PLUGIN_HOOKS[Hooks::HANDLE_WAKEONLAN_TASK]['glpiinventory'] = 'plugin_glpiinventory_handle_wakeonlan_task';
 }
 
 


### PR DESCRIPTION
This permits to notify GLPI-Agent on JSON protocol CONTACT requests
to communicate with GlpiInventory Plugin for netdiscovery, netinventory,
esx, collect, deploy and wakeonlan tasks.

This is a demonstration of [GLPI PR #10316 usage](https://github.com/glpi-project/glpi/pull/10316)

For instance, for such a CONTACT GLPI-Agent requet:
```
{
   "action": "contact",
   "deviceid": "agent-test-2021-11-30-09-57-34",
   "enabled-tasks": [
      "inventory",
      "netdiscovery",
      "netinventory",
      "remoteinventory"
   ],
   "installed-tasks": [
      "collect",
      "deploy",
      "esx",
      "inventory",
      "netdiscovery",
      "netinventory",
      "remoteinventory",
      "wakeonlan"
   ],
   "name": "GLPI-Agent",
   "version": "1.1-dev"
}
```
It permits to answer this to the agent:
```
{"message":"remoteinventory task not supported","disabled":["remoteinventory"],"expiration":24,"status":"ok","tasks":{"inventory":{"server":"glpi","version":"10.0.0-dev"},"netdiscovery":{"version":"1.0.0-rc3","server":"glpiinventory"},"netinventory":{"version":"1.0.0-rc3","server":"glpiinventory"}}}
```
The answer permits to tell the agent enabled tasks supported by the plugin can be run by the agent when the agent first communicates with GLPI via JSON protocol.

At the moment, the agent still requires to be modified so, with such an answer, it can still have to make a PROLOG request using XML-based protocol for some tasks.