### PR TITLE
Support agent exit message

### DIFF
--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -72,7 +72,8 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                 $pfTaskjobstate->changeStatus($a_CONTENT->jobid, 2);
                 if (
                     (!isset($a_CONTENT->content->agent->start))
-                    and (!isset($a_CONTENT->content->agent->end))
+                    && (!isset($a_CONTENT->content->agent->end))
+                    && (!isset($a_CONTENT->content->agent->exit))
                 ) {
                     $nb_devices = 1;
                     $_SESSION['plugin_glpiinventory_taskjoblog']['taskjobs_id'] = $a_CONTENT->jobid;
@@ -87,7 +88,10 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
 
         if ($pfTaskjobstate->getFromDB($a_CONTENT->jobid)) {
             if ($pfTaskjobstate->fields['state'] != PluginGlpiinventoryTaskjobstate::FINISHED) {
-                if (isset($a_CONTENT->content->agent->end)) {
+                if (isset($a_CONTENT->content->agent->exit)) {
+                    $pfTaskjobstate->fail('Task aborted by agent');
+                    $response['response'] = ['RESPONSE' => 'SEND'];
+                } elseif (isset($a_CONTENT->content->agent->end)) {
                     $updated = countElementsInTable(
                         'glpi_plugin_glpiinventory_taskjoblogs',
                         [

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -97,7 +97,7 @@ class PluginGlpiinventoryCommunicationNetworkInventory
         }
 
         $_SESSION['glpi_plugin_glpiinventory_processnumber'] = $a_CONTENT->jobid;
-        if ((!isset($a_CONTENT->content->agent->start)) and (!isset($a_CONTENT->content->agent->end))) {
+        if ((!isset($a_CONTENT->content->agent->start)) && (!isset($a_CONTENT->content->agent->end)) && (!isset($a_CONTENT->content->agent->exit))) {
             $nb_devices = 1;
             $_SESSION['plugin_glpiinventory_taskjoblog']['taskjobs_id'] =
               $a_CONTENT->jobid;
@@ -109,7 +109,10 @@ class PluginGlpiinventoryCommunicationNetworkInventory
             $this->addtaskjoblog();
         }
 
-        if (isset($a_CONTENT->content->agent->end)) {
+        if (isset($a_CONTENT->content->agent->exit)) {
+            $pfTaskjobstate->fail('Task aborted by agent');
+            $response['response'] = ['RESPONSE' => 'SEND'];
+        } elseif (isset($a_CONTENT->content->agent->end)) {
             $cnt = countElementsInTable(
                 'glpi_plugin_glpiinventory_taskjoblogs',
                 [


### PR DESCRIPTION
As GLPI Agent is able to abort netdiscovery or netinventory tasks on an expiration timeout, we need to handle the related message on server-side.
This PR will permit to obtain such result:
![image](https://user-images.githubusercontent.com/12514489/149789231-5bc63e6a-e043-4d44-8750-d7ceabfd9514.png)
Here is the XML message sample sent by the agent:
```
<?xml version="1.0" encoding="UTF-8" ?>
<REQUEST>
  <CONTENT>
    <AGENT>
      <EXIT>1</EXIT>
    </AGENT>
    <MODULEVERSION>4.4</MODULEVERSION>
    <PROCESSNUMBER>106</PROCESSNUMBER>
  </CONTENT>
  <DEVICEID>xxxxxxxx-2021-11-30-09-57-34</DEVICEID>
  <QUERY>NETDISCOVERY</QUERY>
</REQUEST>
```
And without that PR, the server answers with a 500 HTTP error without logging anything in `php-errors.log` and the task is kept in a `running` state.