### PR TITLE
Fix typo in license headers

### DIFF
--- a/ajax/cancel_job.php
+++ b/ajax/cancel_job.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/deploy_displaytypevalue.php
+++ b/ajax/deploy_displaytypevalue.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/deployfilemodal.php
+++ b/ajax/deployfilemodal.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/deploypackage_form.php
+++ b/ajax/deploypackage_form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/deployuser.logged.in.php
+++ b/ajax/deployuser.logged.in.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdownCredentials.php
+++ b/ajax/dropdownCredentials.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdown_taskjob.php
+++ b/ajax/dropdown_taskjob.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdownactionlist.php
+++ b/ajax/dropdownactionlist.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdownactionselection.php
+++ b/ajax/dropdownactionselection.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdownactiontype.php
+++ b/ajax/dropdownactiontype.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdowndefinitionlist.php
+++ b/ajax/dropdowndefinitionlist.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdowndefinitionselection.php
+++ b/ajax/dropdowndefinitionselection.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdowndefinitiontype.php
+++ b/ajax/dropdowndefinitiontype.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdowndefinitiontypelist.php
+++ b/ajax/dropdowndefinitiontypelist.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdownjobdefinition.php
+++ b/ajax/dropdownjobdefinition.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdownlist.php
+++ b/ajax/dropdownlist.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdownlocation.php
+++ b/ajax/dropdownlocation.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdowntype.php
+++ b/ajax/dropdowntype.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/dropdowntypelist.php
+++ b/ajax/dropdowntypelist.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/expand_task.php
+++ b/ajax/expand_task.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/jobstates_logs.php
+++ b/ajax/jobstates_logs.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/restart_job.php
+++ b/ajax/restart_job.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/serverfilestreesons.php
+++ b/ajax/serverfilestreesons.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/showtaskjoblogdetail.php
+++ b/ajax/showtaskjoblogdetail.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/taskjob_form.php
+++ b/ajax/taskjob_form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/taskjob_itemtypes.php
+++ b/ajax/taskjob_itemtypes.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/taskjob_logs.php
+++ b/ajax/taskjob_logs.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/taskjob_moduleitems.php
+++ b/ajax/taskjob_moduleitems.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/taskjob_moduletypes.php
+++ b/ajax/taskjob_moduletypes.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/taskjobaddtype.php
+++ b/ajax/taskjobaddtype.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/taskjobdeletetype.php
+++ b/ajax/taskjobdeletetype.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/ajax/taskmethodupdate.php
+++ b/ajax/taskmethodupdate.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/b/collect/index.php
+++ b/b/collect/index.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/b/deploy/index.php
+++ b/b/deploy/index.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/b/esx/index.php
+++ b/b/esx/index.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/css/deploy.css
+++ b/css/deploy.css
@@ -19,7 +19,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/css/views.css
+++ b/css/views.css
@@ -19,7 +19,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/agentmodule.form.php
+++ b/front/agentmodule.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/collect.form.php
+++ b/front/collect.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/collect.php
+++ b/front/collect.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/collect_file.form.php
+++ b/front/collect_file.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/collect_registry.form.php
+++ b/front/collect_registry.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/collect_wmi.form.php
+++ b/front/collect_wmi.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/collectrule.form.php
+++ b/front/collectrule.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/collectrule.php
+++ b/front/collectrule.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/communication.php
+++ b/front/communication.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/credential.form.php
+++ b/front/credential.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/credential.php
+++ b/front/credential.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/credentialip.form.php
+++ b/front/credentialip.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/credentialip.php
+++ b/front/credentialip.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deployfile.clean.php
+++ b/front/deployfile.clean.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deploygroup.form.php
+++ b/front/deploygroup.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deploygroup.php
+++ b/front/deploygroup.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deploymirror.form.php
+++ b/front/deploymirror.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deploymirror.php
+++ b/front/deploymirror.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deploypackage.form.php
+++ b/front/deploypackage.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deploypackage.import.php
+++ b/front/deploypackage.import.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deploypackage.php
+++ b/front/deploypackage.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deployuserinteractiontemplate.form.php
+++ b/front/deployuserinteractiontemplate.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/deployuserinteractiontemplate.php
+++ b/front/deployuserinteractiontemplate.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/documentation.php
+++ b/front/documentation.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/iprange.form.php
+++ b/front/iprange.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/iprange.php
+++ b/front/iprange.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/iprange_snmpcredential.form.php
+++ b/front/iprange_snmpcredential.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/menu.php
+++ b/front/menu.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/menu_snmpinventory.php
+++ b/front/menu_snmpinventory.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/plugin_fusioninventory.communication.php
+++ b/front/plugin_fusioninventory.communication.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/popup.php
+++ b/front/popup.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/rule.common.form.php
+++ b/front/rule.common.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/rule.common.php
+++ b/front/rule.common.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/rule.test.php
+++ b/front/rule.test.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/rulesengine.test.php
+++ b/front/rulesengine.test.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/send.php
+++ b/front/send.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/send_inventory.php
+++ b/front/send_inventory.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/statediscovery.php
+++ b/front/statediscovery.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/stateinventory.php
+++ b/front/stateinventory.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/task.form.php
+++ b/front/task.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/task.php
+++ b/front/task.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/taskjob.form.php
+++ b/front/taskjob.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/taskjob.php
+++ b/front/taskjob.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/taskjoblog.php
+++ b/front/taskjoblog.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/timeslot.form.php
+++ b/front/timeslot.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/timeslot.php
+++ b/front/timeslot.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/front/timeslotentry.form.php
+++ b/front/timeslotentry.form.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/hook.php
+++ b/hook.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/agentmodule.class.php
+++ b/inc/agentmodule.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/agentwakeup.class.php
+++ b/inc/agentwakeup.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collect.class.php
+++ b/inc/collect.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collect_file.class.php
+++ b/inc/collect_file.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collect_file_content.class.php
+++ b/inc/collect_file_content.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collect_registry.class.php
+++ b/inc/collect_registry.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collect_registry_content.class.php
+++ b/inc/collect_registry_content.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collect_wmi.class.php
+++ b/inc/collect_wmi.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collect_wmi_content.class.php
+++ b/inc/collect_wmi_content.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collectcommon.class.php
+++ b/inc/collectcommon.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collectcontentcommon.class.php
+++ b/inc/collectcontentcommon.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collectrule.class.php
+++ b/inc/collectrule.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/collectrulecollection.class.php
+++ b/inc/collectrulecollection.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/commonview.class.php
+++ b/inc/commonview.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/communication.class.php
+++ b/inc/communication.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/communicationrest.class.php
+++ b/inc/communicationrest.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/credential.class.php
+++ b/inc/credential.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/credentialip.class.php
+++ b/inc/credentialip.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deployaction.class.php
+++ b/inc/deployaction.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploycheck.class.php
+++ b/inc/deploycheck.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploycommon.class.php
+++ b/inc/deploycommon.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deployfile.class.php
+++ b/inc/deployfile.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deployfilepart.class.php
+++ b/inc/deployfilepart.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploymirror.class.php
+++ b/inc/deploymirror.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploypackage_entity.class.php
+++ b/inc/deploypackage_entity.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploypackage_group.class.php
+++ b/inc/deploypackage_group.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploypackage_profile.class.php
+++ b/inc/deploypackage_profile.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploypackage_user.class.php
+++ b/inc/deploypackage_user.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploypackageitem.class.php
+++ b/inc/deploypackageitem.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploytask.class.php
+++ b/inc/deploytask.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deploytaskjob.class.php
+++ b/inc/deploytaskjob.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deployuserinteraction.class.php
+++ b/inc/deployuserinteraction.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/deployuserinteractiontemplate.class.php
+++ b/inc/deployuserinteractiontemplate.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/display.class.php
+++ b/inc/display.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/inventorycomputeresx.class.php
+++ b/inc/inventorycomputeresx.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/inventorycomputerstat.class.php
+++ b/inc/inventorycomputerstat.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/iprange.class.php
+++ b/inc/iprange.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/iprange_snmpcredential.class.php
+++ b/inc/iprange_snmpcredential.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/module.class.php
+++ b/inc/module.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/networkdiscovery.class.php
+++ b/inc/networkdiscovery.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/setup.class.php
+++ b/inc/setup.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/statediscovery.class.php
+++ b/inc/statediscovery.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/stateinventory.class.php
+++ b/inc/stateinventory.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/staticmisc.class.php
+++ b/inc/staticmisc.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/taskjob.class.php
+++ b/inc/taskjob.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/taskjoblog.class.php
+++ b/inc/taskjoblog.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/taskjobstate.class.php
+++ b/inc/taskjobstate.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/timeslot.class.php
+++ b/inc/timeslot.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/timeslotentry.class.php
+++ b/inc/timeslotentry.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/inc/wakeonlan.class.php
+++ b/inc/wakeonlan.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/install/climigration.class.php
+++ b/install/climigration.class.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/install/install.php
+++ b/install/install.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/install/mysql/plugin_glpiinventory-empty.sql
+++ b/install/mysql/plugin_glpiinventory-empty.sql
@@ -19,7 +19,7 @@
 -- the Free Software Foundation, either version 3 of the License, or
 -- (at your option) any later version.
 --
--- GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+-- GLPI Inventory Plugin is distributed in the hope that it will be useful,
 -- but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 -- GNU Affero General Public License for more details.

--- a/install/update.native.php
+++ b/install/update.native.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/install/update.php
+++ b/install/update.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/install/update.tasks.php
+++ b/install/update.tasks.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/js/stats.js
+++ b/js/stats.js
@@ -19,7 +19,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -19,7 +19,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/report/computer_last_inventory.php
+++ b/report/computer_last_inventory.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/report/not_queried_recently.php
+++ b/report/not_queried_recently.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/report/ports_date_connections.php
+++ b/report/ports_date_connections.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/report/switch_ports.history.php
+++ b/report/switch_ports.history.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/setup.php
+++ b/setup.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/templates/forms/deploymirror.html.twig
+++ b/templates/forms/deploymirror.html.twig
@@ -19,7 +19,7 @@
  # the Free Software Foundation, either version 3 of the License, or
  # (at your option) any later version.
  #
- # GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ # GLPI Inventory Plugin is distributed in the hope that it will be useful,
  # but WITHOUT ANY WARRANTY; without even the implied warranty of
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  # GNU Affero General Public License for more details.

--- a/templates/forms/deployuserinteractiontemplate.html.twig
+++ b/templates/forms/deployuserinteractiontemplate.html.twig
@@ -19,7 +19,7 @@
  # the Free Software Foundation, either version 3 of the License, or
  # (at your option) any later version.
  #
- # GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ # GLPI Inventory Plugin is distributed in the hope that it will be useful,
  # but WITHOUT ANY WARRANTY; without even the implied warranty of
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  # GNU Affero General Public License for more details.

--- a/templates/forms/iprange.html.twig
+++ b/templates/forms/iprange.html.twig
@@ -19,7 +19,7 @@
  # the Free Software Foundation, either version 3 of the License, or
  # (at your option) any later version.
  #
- # GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ # GLPI Inventory Plugin is distributed in the hope that it will be useful,
  # but WITHOUT ANY WARRANTY; without even the implied warranty of
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  # GNU Affero General Public License for more details.

--- a/templates/submenu.html.twig
+++ b/templates/submenu.html.twig
@@ -19,7 +19,7 @@
  # the Free Software Foundation, either version 3 of the License, or
  # (at your option) any later version.
  #
- # GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ # GLPI Inventory Plugin is distributed in the hope that it will be useful,
  # but WITHOUT ANY WARRANTY; without even the implied warranty of
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  # GNU Affero General Public License for more details.

--- a/tests/Installation/DatabaseTestsCommons.php
+++ b/tests/Installation/DatabaseTestsCommons.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Installation/InstallationTest.php
+++ b/tests/Installation/InstallationTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Installation/UpdateTest.php
+++ b/tests/Installation/UpdateTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Installation/mysql/i-0.83+2.1.sql
+++ b/tests/Installation/mysql/i-0.83+2.1.sql
@@ -19,7 +19,7 @@
 -- the Free Software Foundation, either version 3 of the License, or
 -- (at your option) any later version.
 --
--- GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+-- GLPI Inventory Plugin is distributed in the hope that it will be useful,
 -- but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 -- GNU Affero General Public License for more details.

--- a/tests/Integration/CollectRuleTest.php
+++ b/tests/Integration/CollectRuleTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/CollectsTest.php
+++ b/tests/Integration/CollectsTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/ComputerEntityTest.php
+++ b/tests/Integration/ComputerEntityTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Deploy/DeploymirrorIntTest.php
+++ b/tests/Integration/Deploy/DeploymirrorIntTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Deploy/PackageSelfDeployTest.php
+++ b/tests/Integration/Deploy/PackageSelfDeployTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Deploy/RepositoryTest.php
+++ b/tests/Integration/Deploy/RepositoryTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Deploy/TaskDeployDynamicGroupTest.php
+++ b/tests/Integration/Deploy/TaskDeployDynamicGroupTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/RestURLTest.php
+++ b/tests/Integration/RestURLTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/RuleImportTest.php
+++ b/tests/Integration/RuleImportTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Tasks/CronTaskTest.php
+++ b/tests/Integration/Tasks/CronTaskTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Tasks/DeleteTaskTest.php
+++ b/tests/Integration/Tasks/DeleteTaskTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Tasks/GetTaskByFiltersTest.php
+++ b/tests/Integration/Tasks/GetTaskByFiltersTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Tasks/NetworkDiscoveryTest.php
+++ b/tests/Integration/Tasks/NetworkDiscoveryTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Integration/Tasks/NetworkInventoryTest.php
+++ b/tests/Integration/Tasks/NetworkInventoryTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/LogTest.php
+++ b/tests/LogTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/DeleteLinkedObjectsTest.php
+++ b/tests/Unit/DeleteLinkedObjectsTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/Deploy/DeployUserinteractionTemplateTest.php
+++ b/tests/Unit/Deploy/DeployUserinteractionTemplateTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/Deploy/DeployUserinteractionTest.php
+++ b/tests/Unit/Deploy/DeployUserinteractionTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/Deploy/DeployactionTest.php
+++ b/tests/Unit/Deploy/DeployactionTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/Deploy/DeploycheckTest.php
+++ b/tests/Unit/Deploy/DeploycheckTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/Deploy/DeploygroupTest.php
+++ b/tests/Unit/Deploy/DeploygroupTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/Deploy/DeploymirrorTest.php
+++ b/tests/Unit/Deploy/DeploymirrorTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/Deploy/DeploypackageTest.php
+++ b/tests/Unit/Deploy/DeploypackageTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/Deploy/PackageJsonTest.php
+++ b/tests/Unit/Deploy/PackageJsonTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/NetworkEquipmentUpdateDiscoveryTest.php
+++ b/tests/Unit/NetworkEquipmentUpdateDiscoveryTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/NetworkEquipmentUpdateTest.php
+++ b/tests/Unit/NetworkEquipmentUpdateTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/PrinterUpdateTest.php
+++ b/tests/Unit/PrinterUpdateTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/TaskTest.php
+++ b/tests/Unit/TaskTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/TimeslotTest.php
+++ b/tests/Unit/TimeslotTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/Unit/ToolboxTest.php
+++ b/tests/Unit/ToolboxTest.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -21,7 +21,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.

--- a/tools/HEADER
+++ b/tools/HEADER
@@ -18,7 +18,7 @@ it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+GLPI Inventory Plugin is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -20,7 +20,7 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+# GLPI Inventory Plugin is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.

--- a/tools/phpdoc.sh
+++ b/tools/phpdoc.sh
@@ -19,7 +19,7 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+# GLPI Inventory Plugin is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.

--- a/tools/update_mo.pl
+++ b/tools/update_mo.pl
@@ -21,7 +21,7 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# GLPI Inventoruy Plugin is distributed in the hope that it will be useful,
+# GLPI Inventory Plugin is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.


### PR DESCRIPTION
"Inventoruy" -> "Inventory" in plugin's name in license headers.