### PR TITLE
Fix TaskJob migration

### DIFF
--- a/install/update.native.php
+++ b/install/update.native.php
@@ -670,5 +670,44 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
                 ]
             )
         );
+
+        if ($DB->tableExists('glpi_plugin_glpiinventory_taskjobs')) {
+            $taskjobs_iterator = $DB->request(['FROM' => 'glpi_plugin_glpiinventory_taskjobs']);
+            foreach ($taskjobs_iterator as $taskjob) {
+                $updated_values = [
+                    'actors'  => [],
+                    'targets' => [],
+                ];
+                foreach (['actors', 'targets'] as $fieldname) {
+                    $existing_values = importArrayFromDB($taskjob[$fieldname]);
+                    foreach ($existing_values as $key => $item_specs) {
+                        $itemtype = key($item_specs);
+                        $items_id = current($item_specs);
+                        if ($itemtype === 'PluginFusioninventoryAgent') {
+                            $itemtype = 'Agent';
+                            if (array_key_exists($items_id, $agents_mapping)) {
+                                $items_id = $agents_mapping[$items_id];
+                            }
+                        } else {
+                            $itemtype = str_replace('PluginFusioninventory', 'PluginGlpiinventory', $itemtype);
+                        }
+                        $updated_values[$fieldname][] = [$itemtype => $items_id];
+                    }
+                }
+
+                $DB->queryOrDie(
+                    $DB->buildUpdate(
+                        'glpi_plugin_glpiinventory_taskjobs',
+                        [
+                            'actors'  => exportArrayToDB($updated_values['actors']),
+                            'targets' => exportArrayToDB($updated_values['targets'])
+                        ],
+                        [
+                            'id' => $taskjob['id']
+                        ]
+                    )
+                );
+            }
+        }
     }
 }

--- a/install/update.php
+++ b/install/update.php
@@ -749,9 +749,9 @@ function pluginGlpiinventoryUpdate($current_version, $migrationname = 'Migration
         foreach ($iterator as $data) {
             $a_defs = importArrayFromDB($data['targets']);
             foreach ($a_defs as $num => $a_def) {
-                if (key($a_def) == 'PluginFusinvsnmpIPRange') {
+                if (in_array(key($a_def), ['PluginFusinvsnmpIPRange', 'PluginFusioninventoryIPRange'])) {
                     $a_defs[$num] = ['PluginGlpiinventoryIPRange' => current($a_def)];
-                } elseif (key($a_def) == 'PluginFusinvdeployPackage') {
+                } elseif (in_array(key($a_def), ['PluginFusinvdeployPackage', 'PluginFusioninventoryDeployPackage'])) {
                     $a_defs[$num] = ['PluginGlpiinventoryDeployPackage' => current($a_def)];
                 }
             }


### PR DESCRIPTION
`taskjobs` table contains fields that are containing some itemtypes/items_id in a serialized format, which was not handle by migration.