### PR TITLE
Rename PluginFusioninventory -> PluginGlpiinventory earlier

### DIFF
--- a/install/update.native.php
+++ b/install/update.native.php
@@ -613,13 +613,13 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
 
     // Remove old display preferences
     $displaypref = new DisplayPreference();
-    $displaypref->deleteByCriteria(['itemtype' => 'PluginFusioninventoryAgent'], true, false);
-    $displaypref->deleteByCriteria(['itemtype' => 'PluginFusioninventoryUnmanaged'], true, false);
+    $displaypref->deleteByCriteria(['itemtype' => 'PluginGlpiinventoryAgent'], true, false);
+    $displaypref->deleteByCriteria(['itemtype' => 'PluginGlpiinventoryUnmanaged'], true, false);
 
     //Fix old types
     $types = [
-        'PluginFusioninventoryAgent' => 'Agent',
-        'PluginFusioninventoryUnmanaged' => 'Unmanaged'
+        'PluginGlpiinventoryAgent' => 'Agent',
+        'PluginGlpiinventoryUnmanaged' => 'Unmanaged'
     ];
 
     $mappings = [
@@ -698,22 +698,7 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
             $DB->buildDelete(
                 $table_name,
                 [
-                    $itemtype_col => 'PluginFusioninventoryIgnoredimportdevice'
-                ]
-            )
-        );
-
-        $migration->addPostQuery(
-            $DB->buildUpdate(
-                $table_name,
-                [
-                    $itemtype_col => new \QueryExpression(
-                        'REPLACE(' . $DB->quoteName($itemtype_col) . ', "PluginFusioninventory", "PluginGlpiinventory")'
-                    )
-
-                ],
-                [
-                    $itemtype_col => ['LIKE', 'PluginFusion%']
+                    $itemtype_col => 'PluginGlpiinventoryIgnoredimportdevice'
                 ]
             )
         );
@@ -727,16 +712,14 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
                 ];
                 foreach (['actors', 'targets'] as $fieldname) {
                     $existing_values = importArrayFromDB($taskjob[$fieldname]);
-                    foreach ($existing_values as $key => $item_specs) {
+                    foreach ($existing_values as $item_specs) {
                         $itemtype = key($item_specs);
                         $items_id = current($item_specs);
-                        if ($itemtype === 'PluginFusioninventoryAgent') {
+                        if ($itemtype === 'PluginGlpiinventoryAgent') {
                             $itemtype = 'Agent';
                             if (array_key_exists($items_id, $agents_mapping)) {
                                 $items_id = $agents_mapping[$items_id];
                             }
-                        } else {
-                            $itemtype = str_replace('PluginFusioninventory', 'PluginGlpiinventory', $itemtype);
                         }
                         $updated_values[$fieldname][] = [$itemtype => $items_id];
                     }

--- a/install/update.native.php
+++ b/install/update.native.php
@@ -715,11 +715,13 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
                     foreach ($existing_values as $item_specs) {
                         $itemtype = key($item_specs);
                         $items_id = current($item_specs);
-                        if ($itemtype === 'PluginGlpiinventoryAgent') {
+                        if ($itemtype === 'PluginGlpiinventoryAgent' || $itemtype === 'PluginFusioninventoryAgent') {
                             $itemtype = 'Agent';
                             if (array_key_exists($items_id, $agents_mapping)) {
                                 $items_id = $agents_mapping[$items_id];
                             }
+                        } else {
+                            $itemtype = str_replace('PluginFusioninventory', 'PluginGlpiinventory', $itemtype);
                         }
                         $updated_values[$fieldname][] = [$itemtype => $items_id];
                     }

--- a/install/update.php
+++ b/install/update.php
@@ -760,9 +760,9 @@ function pluginGlpiinventoryUpdate($current_version, $migrationname = 'Migration
         foreach ($iterator as $data) {
             $a_defs = importArrayFromDB($data['targets']);
             foreach ($a_defs as $num => $a_def) {
-                if (in_array(key($a_def), ['PluginFusinvsnmpIPRange'])) {
+                if (in_array(key($a_def), ['PluginFusinvsnmpIPRange', 'PluginFusioninventoryIPRange'])) {
                     $a_defs[$num] = ['PluginGlpiinventoryIPRange' => current($a_def)];
-                } elseif (in_array(key($a_def), ['PluginFusinvdeployPackage'])) {
+                } elseif (in_array(key($a_def), ['PluginFusinvdeployPackage', 'PluginFusioninventoryDeployPackage'])) {
                     $a_defs[$num] = ['PluginGlpiinventoryDeployPackage' => current($a_def)];
                 }
             }

--- a/install/update.php
+++ b/install/update.php
@@ -8593,19 +8593,35 @@ function renamePlugin(Migration $migration)
     $itemtypes_iterator = $DB->request(
         [
             'SELECT' => [
-                'table_name AS TABLE_NAME',
-                'column_name AS COLUMN_NAME',
+                'information_schema.columns.table_name AS TABLE_NAME',
+                'information_schema.columns.column_name AS COLUMN_NAME',
             ],
             'FROM'   => 'information_schema.columns',
+            'INNER JOIN'   => [
+                'information_schema.tables' => [
+                    'FKEY' => [
+                        'information_schema.tables'  => 'table_name',
+                        'information_schema.columns' => 'table_name',
+                        [
+                            'AND' => [
+                                'information_schema.tables.table_schema' => new QueryExpression(
+                                    $DB->quoteName('information_schema.columns.table_schema')
+                                ),
+                            ]
+                        ],
+                    ]
+                ]
+            ],
             'WHERE'  => [
-                'table_schema' => $DB->dbdefault,
-                'table_name'   => ['LIKE', 'glpi\_%'],
+                'information_schema.tables.table_type'    => 'BASE TABLE',
+                'information_schema.columns.table_schema' => $DB->dbdefault,
+                'information_schema.columns.table_name'   => ['LIKE', 'glpi\_%'],
                 'OR' => [
-                    ['column_name'  => 'itemtype'],
-                    ['column_name'  => ['LIKE', 'itemtype_%']],
+                    ['information_schema.columns.column_name'  => 'itemtype'],
+                    ['information_schema.columns.column_name'  => ['LIKE', 'itemtype_%']],
                 ],
             ],
-            'ORDER'  => 'TABLE_NAME',
+            'ORDER'  => 'information_schema.columns.table_name',
         ]
     );
 

--- a/install/update.php
+++ b/install/update.php
@@ -361,6 +361,17 @@ function pluginGlpiinventoryUpdate($current_version, $migrationname = 'Migration
         unset($gzfiles);
     }
 
+    // Drop unused views
+    // Have to be done prior to renamePlugin() to prevent following warning:
+    // "View 'glpi.glpi_plugin_fusinvdeploy_taskjobs' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them"
+    $old_deploy_views = [
+      'glpi_plugin_fusinvdeploy_taskjobs',
+      'glpi_plugin_fusinvdeploy_tasks'
+    ];
+    foreach ($old_deploy_views as $view) {
+        $DB->query("DROP VIEW IF EXISTS $view");
+    }
+
     renamePlugin($migration);
 
    // conversion in very old version
@@ -749,9 +760,9 @@ function pluginGlpiinventoryUpdate($current_version, $migrationname = 'Migration
         foreach ($iterator as $data) {
             $a_defs = importArrayFromDB($data['targets']);
             foreach ($a_defs as $num => $a_def) {
-                if (in_array(key($a_def), ['PluginFusinvsnmpIPRange', 'PluginFusioninventoryIPRange'])) {
+                if (in_array(key($a_def), ['PluginFusinvsnmpIPRange'])) {
                     $a_defs[$num] = ['PluginGlpiinventoryIPRange' => current($a_def)];
-                } elseif (in_array(key($a_def), ['PluginFusinvdeployPackage', 'PluginFusioninventoryDeployPackage'])) {
+                } elseif (in_array(key($a_def), ['PluginFusinvdeployPackage'])) {
                     $a_defs[$num] = ['PluginGlpiinventoryDeployPackage' => current($a_def)];
                 }
             }
@@ -8558,15 +8569,6 @@ function migrateTablesFromFusinvDeploy($migration)
     ];
     foreach ($old_deploy_tables as $table) {
         $migration->dropTable($table);
-    }
-
-   //drop unused views
-    $old_deploy_views = [
-      'glpi_plugin_fusinvdeploy_taskjobs',
-      'glpi_plugin_fusinvdeploy_tasks'
-    ];
-    foreach ($old_deploy_views as $view) {
-        $DB->query("DROP VIEW IF EXISTS $view");
     }
 }
 

--- a/install/update.php
+++ b/install/update.php
@@ -8613,18 +8613,16 @@ function renamePlugin(Migration $migration)
         $table_name   = $itemtype['TABLE_NAME'];
         $itemtype_col = $itemtype['COLUMN_NAME'];
 
-        $migration->addPostQuery(
-            $DB->buildUpdate(
-                $table_name,
-                [
-                    $itemtype_col => new \QueryExpression(
-                        'REPLACE(' . $DB->quoteName($itemtype_col) . ', "PluginFusioninventory", "PluginGlpiinventory")'
-                    )
-                ],
-                [
-                    $itemtype_col => ['LIKE', 'PluginFusioninventory%']
-                ]
-            )
+        $DB->update(
+            $table_name,
+            [
+                $itemtype_col => new \QueryExpression(
+                    'REPLACE(' . $DB->quoteName($itemtype_col) . ', "PluginFusioninventory", "PluginGlpiinventory")'
+                )
+            ],
+            [
+                $itemtype_col => ['LIKE', 'PluginFusioninventory%']
+            ]
         );
     }
 }


### PR DESCRIPTION
See https://github.com/glpi-project/glpi/issues/10817#issuecomment-1070676196

Based on following code, crontasks are "duplicated" when migrating from `FusionInventory`.
```php
    if (!$crontask->getFromDBbyName('PluginGlpiinventoryAgentWakeup', 'wakeupAgents')) {
        CronTask::Register(
            'PluginGlpiinventoryAgentWakeup',
            'wakeupAgents',
            120,
            ['mode' => 2, 'allowmode' => 3, 'logs_lifetime' => 30,
            'comment' => Toolbox::addslashes_deep(__('Wake agents ups'))]
        );
    }
```

There are probably other issues based on same logic.

To fix this, itemtypes should be renamed earlier, in the `renamePlugin()` function.