### PR TITLE
Prevent migration error when transfers_id_auto is negative

### DIFF
--- a/install/update.native.php
+++ b/install/update.native.php
@@ -588,7 +588,7 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
               FROM `glpi_plugin_glpiinventory_entities`
           ) AS `plugin_entities` ON `plugin_entities`.`entities_id` = `entities`.`id`
           SET
-              `entities`.`transfers_id` = GREATEST(0, `plugin_entities`.`transfers_id_auto`),
+              `entities`.`transfers_id` = `plugin_entities`.`transfers_id_auto`,
               `entities`.`agent_base_url` = `plugin_entities`.`agent_base_url`
           ;"
         );

--- a/install/update.php
+++ b/install/update.php
@@ -1725,6 +1725,15 @@ function do_entities_migration($migration)
 
     $a_table['oldkeys'] = [];
 
+    // Fix -1 values in `transfers_id_auto`
+    if ($DB->tableExists('glpi_plugin_glpiinventory_entities') && $DB->fieldExists('glpi_plugin_glpiinventory_entities', 'transfers_id_auto')) {
+        $DB->update(
+            'glpi_plugin_glpiinventory_entities',
+            ['transfers_id_auto' => '0'],
+            ['transfers_id_auto' => '-1'],
+        );
+    }
+
     migratePluginTables($migration, $a_table);
     if (countElementsInTable($a_table['name']) == 0) {
         $a_configs = getAllDataFromTable(


### PR DESCRIPTION
#118 does not fix completely the issue.

The issue appears ealier, in `do_entities_migration()` function, that tries to change field type to unsigned.

![image](https://user-images.githubusercontent.com/33253653/170964539-d122a725-844b-4927-8065-5f5f01258be0.png)
