### PR TITLE
Update net tasks log

### DIFF
--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -73,6 +73,7 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                 if (
                     (!isset($a_CONTENT->content->agent->start))
                     && (!isset($a_CONTENT->content->agent->end))
+                    && (!isset($a_CONTENT->content->agent->nbip))
                     && (!isset($a_CONTENT->content->agent->exit))
                 ) {
                     $nb_devices = 1;

--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -140,22 +140,22 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                                 foreach (["type", "name", "mac", "ips"] as $property) {
                                     if (property_exists($device, $property)) {
                                         if (is_array($device->$property)) {
-                                            $a_text[] = "[".$property."]: ".implode(", ", $device->$property);
+                                            $a_text[] = "[" . $property . "]: " . implode(", ", $device->$property);
                                         } else {
-                                            $a_text[] = "[".$property."]: ".$device->$property;
+                                            $a_text[] = "[" . $property . "]: " . $device->$property;
                                         }
                                     }
                                 }
                             }
-                            $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '==importdenied== '.implode(", ", $a_text);
+                            $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '==importdenied== ' . implode(", ", $a_text);
                             $this->addtaskjoblog();
                         } else {
                             $item = $inventory->getMainAsset()->getItem();
                             // this is an update if at least 'last_inventory_update' can be found in old values
                             $what = count($item->oldvalues) ? '==updatetheitem==' : '==addtheitem==';
                             $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] =
-                                '[==detail==] '.$what.' '.$item->getTypeName().
-                                ' [['.$device->type.'::'.$item->fields['id'].']]';
+                                '[==detail==] ' . $what . ' ' . $item->getTypeName() .
+                                ' [[' . $device->type . '::' . $item->fields['id'] . ']]';
                             $this->addtaskjoblog();
                         }
                         $response = ['response' => ['RESPONSE' => 'SEND']];

--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -132,7 +132,32 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                             $response = ['response' => ['ERROR' => $error]];
                         }
                     } else {
-                     //nothing to do.
+                        $refused = $inventory->getMainAsset()->getRefused();
+                        $device = $a_CONTENT->content->network_device;
+                        if (isset($refused) && count($refused)) {
+                            $a_text = [];
+                            if (isset($device)) {
+                                foreach (["type", "name", "mac", "ips"] as $property) {
+                                    if (property_exists($device, $property)) {
+                                        if (is_array($device->$property)) {
+                                            $a_text[] = "[".$property."]: ".implode(", ", $device->$property);
+                                        } else {
+                                            $a_text[] = "[".$property."]: ".$device->$property;
+                                        }
+                                    }
+                                }
+                            }
+                            $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '==importdenied== '.implode(", ", $a_text);
+                            $this->addtaskjoblog();
+                        } else {
+                            $item = $inventory->getMainAsset()->getItem();
+                            // this is an update if at least 'last_inventory_update' can be found in old values
+                            $what = count($item->oldvalues) ? '==updatetheitem==' : '==addtheitem==';
+                            $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] =
+                                '[==detail==] '.$what.' '.$item->getTypeName().
+                                ' [['.$device->type.'::'.$item->fields['id'].']]';
+                            $this->addtaskjoblog();
+                        }
                         $response = ['response' => ['RESPONSE' => 'SEND']];
                     }
                 } else {

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -167,20 +167,20 @@ class PluginGlpiinventoryCommunicationNetworkInventory
                         foreach (["type", "name", "mac", "ips"] as $property) {
                             if (property_exists($device, $property)) {
                                 if (is_array($device->$property)) {
-                                    $a_text[] = "[".$property."]: ".implode(", ", $device->$property);
+                                    $a_text[] = "[" . $property . "]: " . implode(", ", $device->$property);
                                 } else {
-                                    $a_text[] = "[".$property."]: ".$device->$property;
+                                    $a_text[] = "[" . $property . "]: " . $device->$property;
                                 }
                             }
                         }
                     }
-                    $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '==importdenied== '.implode(", ", $a_text);
+                    $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '==importdenied== ' . implode(", ", $a_text);
                     $this->addtaskjoblog();
                 } else {
                     $item = $inventory->getMainAsset()->getItem();
                     $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] =
-                        '[==detail==] ==updatetheitem== '.$item->getTypeName().
-                        ' [['.$device->type.'::'.$item->fields['id'].']]';
+                        '[==detail==] ==updatetheitem== ' . $item->getTypeName() .
+                        ' [[' . $device->type . '::' . $item->fields['id'] . ']]';
                     $this->addtaskjoblog();
                 }
                 $response = ['response' => ['RESPONSE' => 'SEND']];


### PR DESCRIPTION
Few task job log was missing after the backport. This PR makes them available again.
It also fix the count of devices during netdiscovery task.

Here is a screenshot of a netdiscovery task before the patch:
![image](https://user-images.githubusercontent.com/12514489/174612944-5d263b13-3685-4e94-8cf8-6b775f3b1aa0.png)

Here is the result after the patch is applied:
![image](https://user-images.githubusercontent.com/12514489/174613023-3b21c35e-8c6f-4a04-8df7-75ceea4af645.png)

We can see the difference also on the netdiscovery status page of jobs:
![image](https://user-images.githubusercontent.com/12514489/174613354-0a5a7643-f0fe-4528-a1bd-10e05e2dc3ee.png)
