### PR TITLE
fix(refresh): fix unselected option

### DIFF
--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -1220,7 +1220,7 @@ taskjobs.init_tasks_expand_buttons = function() {
 taskjobs.init_refresh_form = function( ajax_url, task_id, refresh_id) {
 
    $("#"+ refresh_id)
-      .off("change")
+      .off("change", "*")
       .on("change", function() {
          taskjobs.update_logs_timeout( ajax_url, task_id, refresh_id );
       }


### PR DESCRIPTION
From Job Log refresh rate is broken

Change refresh is well taken into account by plugin, but never "selected" in ```select``` dom

![image](https://user-images.githubusercontent.com/7335054/174963078-43184dd0-2677-4f9a-8ce3-e4d0f7080a20.png)
