### PR TITLE
fix(taskjoblog): prevent error on classname

### DIFF
--- a/inc/taskjoblog.class.php
+++ b/inc/taskjoblog.class.php
@@ -753,7 +753,7 @@ function appear_array(id) {
         preg_match_all("/\[\[(.*)\:\:(.*)\]\]/", $comment, $matches);
         foreach ($matches[0] as $num => $commentvalue) {
             $classname = $matches[1][$num];
-            if ($classname != '') {
+            if ($classname != '' && class_exists($classname)) {
                 $Class = new $classname();
                 $Class->getFromDB($matches[2][$num]);
                 $comment = str_replace($commentvalue, $Class->getLink(), $comment);


### PR DESCRIPTION
Prevent fatal error when task job log is displayed

```
[2022-06-22 15:52:40] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class "Networking" not found in /var/www/glpi/marketplace/glpiinventory/inc/taskjoblog.class.php at line 757
  Backtrace :
  ...ce/glpiinventory/inc/taskjobstate.class.php:447 PluginGlpiinventoryTaskjoblog::convertComment()
  ...ce/glpiinventory/inc/taskjobstate.class.php:406 PluginGlpiinventoryTaskjobstate->getLogs()
  ...tplace/glpiinventory/ajax/jobstates_logs.php:48 PluginGlpiinventoryTaskjobstate->ajaxGetLogs()
```