### PR TITLE
fix(migration): fix migration

### DIFF
--- a/install/update.native.php
+++ b/install/update.native.php
@@ -137,7 +137,7 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
     $migration->dropKey('glpi_plugin_glpiinventory_taskjobstates', 'plugin_glpiinventory_agents_id');
     $migration->addKey('glpi_plugin_glpiinventory_taskjobstates', 'agents_id', 'agents_id');
 
-    if ($DB->fieldExists('glpi_plugin_glpiinventory_taskjobstates', 'plugin_glpiinventory_agents_id')) {
+    if ($DB->fieldExists('glpi_plugin_glpiinventory_statediscoveries', 'plugin_glpiinventory_agents_id')) {
         $migration->changeField(
             'glpi_plugin_glpiinventory_statediscoveries',
             'plugin_glpiinventory_agents_id',

--- a/install/update.native.php
+++ b/install/update.native.php
@@ -113,10 +113,10 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
                         $DB->buildUpdate(
                             $agent_table,
                             [
-                                'plugin_glpiinventory_agents_id' => $new_agent_id
+                                'agents_id' => $new_agent_id
                             ],
                             [
-                                'plugin_glpiinventory_agents_id' => $old_agent_id
+                                'agents_id' => $old_agent_id
                             ]
                         )
                     );

--- a/install/update.native.php
+++ b/install/update.native.php
@@ -126,27 +126,6 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
 
         $migration->dropTable('glpi_plugin_glpiinventory_agents');
     }
-    if ($DB->fieldExists('glpi_plugin_glpiinventory_taskjobstates', 'plugin_glpiinventory_agents_id')) {
-        $migration->changeField(
-            'glpi_plugin_glpiinventory_taskjobstates',
-            'plugin_glpiinventory_agents_id',
-            'agents_id',
-            'int unsigned NOT NULL DEFAULT 0'
-        );
-    }
-    $migration->dropKey('glpi_plugin_glpiinventory_taskjobstates', 'plugin_glpiinventory_agents_id');
-    $migration->addKey('glpi_plugin_glpiinventory_taskjobstates', 'agents_id', 'agents_id');
-
-    if ($DB->fieldExists('glpi_plugin_glpiinventory_statediscoveries', 'plugin_glpiinventory_agents_id')) {
-        $migration->changeField(
-            'glpi_plugin_glpiinventory_statediscoveries',
-            'plugin_glpiinventory_agents_id',
-            'agents_id',
-            'int unsigned NOT NULL DEFAULT 0'
-        );
-    }
-    $migration->dropKey('glpi_plugin_glpiinventory_statediscoveries', 'plugin_glpiinventory_agents_id');
-    $migration->addKey('glpi_plugin_glpiinventory_statediscoveries', 'agents_id', 'agents_id');
 
     if ($DB->tableExists('glpi_plugin_glpiinventory_agentmodules')) {
         $agentmodules_iterator = $DB->request(['FROM' => 'glpi_plugin_glpiinventory_agentmodules']);
@@ -472,14 +451,12 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
             //mappings
             $data_unmanaged['domains_id'] = $data_unmanaged['domain'];
             $data_unmanaged['itemtype'] = $data_unmanaged['item_type'];
-            $data_unmanaged['agents_id'] = $data_unmanaged['plugin_glpiinventory_agents_id'];
             $data_unmanaged['snmpcredentials_id'] = $data_unmanaged['plugin_glpiinventory_configsecurities_id'];
 
             unset(
                 $data_unmanaged['id'],
                 $data_unmanaged['domain'],
                 $data_unmanaged['item_type'],
-                $data_unmanaged['plugin_glpiinventory_agents_id'],
                 $data_unmanaged['plugin_glpiinventory_configsecurities_id']
             );
 
@@ -581,7 +558,7 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
                `items_id`,
                `itemtype`,
                `rules_id`,
-               `plugin_glpiinventory_agents_id`,
+               `agents_id`,
                `method`
              FROM `glpi_plugin_glpiinventory_rulematchedlogs`;"
         );

--- a/install/update.php
+++ b/install/update.php
@@ -2233,7 +2233,7 @@ function do_unmanaged_migration($migration)
                                             'value'   => null];
     $a_table['fields']['accepted']   = ['type'    => 'bool',
                                             'value'   => null];
-    $a_table['fields']['plugin_glpiinventory_agents_id'] = ['type'    => 'int unsigned NOT NULL DEFAULT 0',
+    $a_table['fields']['agents_id'] = ['type'    => 'int unsigned NOT NULL DEFAULT 0',
                                             'value'   => null];
     $a_table['fields']['ip']         = ['type'    => 'string',
                                             'value'   => null];
@@ -2271,17 +2271,20 @@ function do_unmanaged_migration($migration)
       'FK_entities'  => 'entities_id',
       'location'     => 'locations_id',
       'deleted'      => 'is_deleted',
-      'plugin_fusinvsnmp_configsecurities_id' => 'plugin_glpiinventory_configsecurities_id'
+      'plugin_fusinvsnmp_configsecurities_id' => 'plugin_glpiinventory_configsecurities_id',
+      'plugin_glpiinventory_agents_id' => 'agents_id',
        ];
 
     $a_table['keys']   = [
       ['field' => 'entities_id', 'name' => '', 'type' => 'INDEX'],
-      ['field' => 'plugin_glpiinventory_agents_id', 'name' => '', 'type' => 'INDEX'],
+      ['field' => 'agents_id', 'name' => '', 'type' => 'INDEX'],
       ['field' => 'is_deleted', 'name' => '', 'type' => 'INDEX'],
       ['field' => 'date_mod', 'name' => '', 'type' => 'INDEX']
     ];
 
-    $a_table['oldkeys'] = [];
+    $a_table['oldkeys'] = [
+        'plugin_glpiinventory_agents_id',
+    ];
 
     migratePluginTables($migration, $a_table);
 
@@ -2399,20 +2402,24 @@ function do_ignoredimport_migration($migration)
                                             'value'   => null];
     $a_table['fields']['uuid']       = ['type'    => 'string',
                                             'value'   => null];
-    $a_table['fields']['plugin_glpiinventory_agents_id']
+    $a_table['fields']['agents_id']
                                     = ['type'    => 'int unsigned NOT NULL DEFAULT 0',
                                             'value'   => null];
 
     $a_table['oldfields']  = [];
 
-    $a_table['renamefields'] = [];
+    $a_table['renamefields'] = [
+        'plugin_glpiinventory_agents_id' => 'agents_id',
+    ];
 
     $a_table['keys']   = [];
-    $a_table['keys'][] = ['field' => 'plugin_glpiinventory_agents_id',
+    $a_table['keys'][] = ['field' => 'agents_id',
                               'name' => '',
                               'type' => 'INDEX'];
 
-    $a_table['oldkeys'] = [];
+    $a_table['oldkeys'] = [
+        'plugin_glpiinventory_agents_id',
+    ];
 
     migratePluginTables($migration, $a_table);
 }
@@ -2801,11 +2808,20 @@ function do_rulematchedlog_migration($migration)
         "rules_id",
         "int unsigned NOT NULL DEFAULT '0'"
     );
-    $migration->addField(
-        $newTable,
-        "plugin_glpiinventory_agents_id",
-        "int unsigned NOT NULL DEFAULT '0'"
-    );
+    if ($DB->fieldExists($newTable, "plugin_glpiinventory_agents_id")) {
+        $migration->changeField(
+            $newTable,
+            "plugin_glpiinventory_agents_id",
+            "agents_id",
+            "int unsigned NOT NULL DEFAULT '0'"
+        );
+    } else {
+        $migration->addField(
+            $newTable,
+            "agents_id",
+            "int unsigned NOT NULL DEFAULT '0'"
+        );
+    }
     $migration->addField(
         $newTable,
         "method",
@@ -5259,7 +5275,7 @@ function do_statediscovery_migration($migration)
     $migration->changeField(
         $newTable,
         "plugin_glpiinventory_agents_id",
-        "plugin_glpiinventory_agents_id",
+        "agents_id",
         "int unsigned NOT NULL DEFAULT '0'"
     );
     $migration->changeField(
@@ -5329,7 +5345,7 @@ function do_statediscovery_migration($migration)
     );
     $migration->addField(
         $newTable,
-        "plugin_glpiinventory_agents_id",
+        "agents_id",
         "int unsigned NOT NULL DEFAULT '0'"
     );
     $migration->addField(

--- a/install/update.tasks.php
+++ b/install/update.tasks.php
@@ -389,7 +389,9 @@ function pluginGlpiinventoryUpdateTasks($migration, $plugin_id)
       ]
     ];
 
-    $table['renamefields'] = ['plugin_glpiinventory_agents_id' => 'agents_id'];
+    $table['renamefields'] = [
+        'plugin_glpiinventory_agents_id' => 'agents_id',
+    ];
     $table['oldfields'] = [
       'execution_id'
     ];
@@ -422,6 +424,8 @@ function pluginGlpiinventoryUpdateTasks($migration, $plugin_id)
       ]
 
     ];
-    $table['oldkeys'] = ['plugin_glpiinventory_agents_id'];
+    $table['oldkeys'] = [
+        'plugin_glpiinventory_agents_id',
+    ];
     migratePluginTables($migration, $table);
 }

--- a/install/update.tasks.php
+++ b/install/update.tasks.php
@@ -359,7 +359,7 @@ function pluginGlpiinventoryUpdateTasks($migration, $plugin_id)
          'type' => 'varchar(100) DEFAULT NULL',
          'value' => null
       ],
-      'plugin_glpiinventory_agents_id' => [
+      'agents_id' => [
          'type' => 'int unsigned NOT NULL DEFAULT 0',
          'value' => null
       ],
@@ -389,7 +389,7 @@ function pluginGlpiinventoryUpdateTasks($migration, $plugin_id)
       ]
     ];
 
-    $table['renamefields'] = ['agents_id' => 'plugin_glpiinventory_agents_id'];
+    $table['renamefields'] = ['plugin_glpiinventory_agents_id' => 'agents_id'];
     $table['oldfields'] = [
       'execution_id'
     ];
@@ -403,14 +403,14 @@ function pluginGlpiinventoryUpdateTasks($migration, $plugin_id)
       ],
       [
          'field' => [
-            'plugin_glpiinventory_agents_id',
+            'agents_id',
             'state'
          ],
          'name' => '', 'type' => 'INDEX'
       ],
       [
          'field' => [
-            'plugin_glpiinventory_agents_id',
+            'agents_id',
             'plugin_glpiinventory_taskjobs_id',
             'items_id',
             'itemtype',
@@ -422,6 +422,6 @@ function pluginGlpiinventoryUpdateTasks($migration, $plugin_id)
       ]
 
     ];
-    $table['oldkeys'] = [];
+    $table['oldkeys'] = ['plugin_glpiinventory_agents_id'];
     migratePluginTables($migration, $table);
 }

--- a/install/update.tasks.php
+++ b/install/update.tasks.php
@@ -389,7 +389,7 @@ function pluginGlpiinventoryUpdateTasks($migration, $plugin_id)
       ]
     ];
 
-    $table['renamefields'] = [];
+    $table['renamefields'] = ['agents_id' => 'plugin_glpiinventory_agents_id'];
     $table['oldfields'] = [
       'execution_id'
     ];


### PR DESCRIPTION
1. First problem

After migration, table ```glpi_plugin_glpiinventory_statediscoveries``` is not properly migrated.
```agents_id``` is created but old column ```plugin_glpiinventory_agents_id``` is not droped

```sql
mysql> explain glpi_plugin_glpiinventory_statediscoveries;
+---------------------------------+--------------+------+-----+---------+----------------+
| Field                           | Type         | Null | Key | Default | Extra          |
+---------------------------------+--------------+------+-----+---------+----------------+
| id                              | int unsigned | NO   | PRI | NULL    | auto_increment |
| plugin_glpiinventory_taskjob_id | int unsigned | NO   | MUL | 0       |                |
| start_time                      | timestamp    | YES  |     | NULL    |                |
| end_time                        | timestamp    | YES  |     | NULL    |                |
| date_mod                        | timestamp    | YES  |     | NULL    |                |
| threads                         | int          | NO   |     | 0       |                |
| nb_ip                           | int          | NO   |     | 0       |                |
| nb_found                        | int          | NO   |     | 0       |                |
| nb_error                        | int          | NO   |     | 0       |                |
| nb_exists                       | int          | NO   |     | 0       |                |
| nb_import                       | int          | NO   |     | 0       |                |
| agents_id                       | int unsigned | NO   | MUL | 0       |                |
| plugin_glpiinventory_agents_id  | int unsigned | NO   |     | 0       |                |
+---------------------------------+--------------+------+-----+---------+----------------+

```

2. Second problem

For each update (With CLI ```php bin/console glpi:plugin:install -f glpiinventory ```)
For table  ```glpi_plugin_glpiinventory_taskjobstates``` , column ```plugin_glpiinventory_agents_id``` is systematically created (with value 0) and migrate to ```agents_id``` with same value -> 0

We lost all logs because ```glpi_plugin_glpiinventory_taskjobstates.agents_id``` becomes 0