### PR TITLE
fix(joblog): get info from update

### DIFF
--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -152,11 +152,10 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                             $this->addtaskjoblog();
                         } else {
                             $item = $inventory->getMainAsset()->getItem();
-                            // this is an update if at least 'last_inventory_update' can be found in old values
-                            $what = count($item->oldvalues) ? '==updatetheitem==' : '==addtheitem==';
+                            $what = $inventory->getMainAsset()->isNew() ? '==addtheitem==' : '==updatetheitem==' ;
                             $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] =
                                 '[==detail==] ' . $what . ' ' . $item->getTypeName() .
-                                ' [[' . $device->type . '::' . $item->fields['id'] . ']]';
+                                ' [[' . $item::getType() . '::' . $item->fields['id'] . ']]';
                             $this->addtaskjoblog();
                         }
                         $response = ['response' => ['RESPONSE' => 'SEND']];


### PR DESCRIPTION
Do not check ```$item->oldvalues``` to know if object is created or updated

Because inventory reload object after ```doInventory()``` with ```getFromDB```

Work on ```add``` but from ```update```, ```item``` is never reload

See https://github.com/glpi-project/glpi/pull/12013 which fix this

Juste check with ```isNew()```

Before : 

![image](https://user-images.githubusercontent.com/7335054/175906152-344655ab-ea88-43f0-bc92-3bd5fa66a513.png)


After : 

![image](https://user-images.githubusercontent.com/7335054/175906169-0faebb4d-e8e3-41eb-879e-53effe492900.png)
