### PR TITLE
fix(joblog): get info from update (SNMP inventory)

### DIFF
--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -180,7 +180,7 @@ class PluginGlpiinventoryCommunicationNetworkInventory
                     $item = $inventory->getMainAsset()->getItem();
                     $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] =
                         '[==detail==] ==updatetheitem== ' . $item->getTypeName() .
-                        ' [[' . $device->type . '::' . $item->fields['id'] . ']]';
+                        ' [[' . $item::getType() . '::' . $item->fields['id'] . ']]';
                     $this->addtaskjoblog();
                 }
                 $response = ['response' => ['RESPONSE' => 'SEND']];


### PR DESCRIPTION
Fix job log from net inventory (like https://github.com/glpi-project/glpi-inventory-plugin/pull/159)

Before : 
![image](https://user-images.githubusercontent.com/7335054/177288366-6d107f47-78d0-49be-b0b2-afce20f28cc2.png)


After :
![image](https://user-images.githubusercontent.com/7335054/177288409-b6a75454-3a83-4fb3-8d70-c3bb42b6453d.png)
