### PR TITLE
check self deploy package right

### DIFF
--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -34,6 +34,8 @@
 include("../../../inc/includes.php");
 Session::checkLoginUser();
 
+Session::checkRight('plugin_glpiinventory_selfpackage', READ);
+
 Html::helpHeader(
     __('GLPI Inventory'),
     $_SERVER["PHP_SELF"],

--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -2055,6 +2055,10 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
     {
         global $DB;
 
+        if (!Session::haveRight('plugin_glpiinventory_selfpackage', READ)) {
+            return false;
+        }
+
         $table = "glpi_plugin_glpiinventory_deploypackages";
         $where = " WHERE `" . $table . "`.`plugin_glpiinventory_deploygroups_id` > 0 "
               . " AND (";

--- a/tests/Integration/Deploy/PackageSelfDeployTest.php
+++ b/tests/Integration/Deploy/PackageSelfDeployTest.php
@@ -198,6 +198,8 @@ class PackageSelfDeployTest extends TestCase
         $pfDeployPackage_Entity = new PluginGlpiinventoryDeployPackage_Entity();
         $pfDeployGroup          = new PluginGlpiinventoryDeployGroup();
 
+        $_SESSION['glpiactiveprofile']['plugin_glpiinventory_selfpackage'] = READ;
+
         $pfDeployGroup->getFromDBByCrit(['name' => 'all']);
 
         $pfDeployPackage->getFromDBByCrit(['name' => 'test1']);
@@ -227,6 +229,8 @@ class PackageSelfDeployTest extends TestCase
         $pfDeployPackage_Group = new PluginGlpiinventoryDeployPackage_Group();
         $group                 = new Group();
         $pfDeployGroup         = new PluginGlpiinventoryDeployGroup();
+
+        $_SESSION['glpiactiveprofile']['plugin_glpiinventory_selfpackage'] = READ;
 
         $pfDeployGroup->getFromDBByCrit(['name' => 'all']);
 
@@ -266,6 +270,8 @@ class PackageSelfDeployTest extends TestCase
         $pfDeployPackage      = new PluginGlpiinventoryDeployPackage();
         $pfDeployPackage_User = new PluginGlpiinventoryDeployPackage_User();
         $pfDeployGroup         = new PluginGlpiinventoryDeployGroup();
+
+        $_SESSION['glpiactiveprofile']['plugin_glpiinventory_selfpackage'] = READ;
 
         $pfDeployGroup->getFromDBByCrit(['name' => 'all']);
 


### PR DESCRIPTION
It looks like there is a missing check on self package deployment right

This PR fixes the unwanted menu entry GLPI Inventory on profiles without the deployment right, and also checks the right when searching for deployable computers