### PR TITLE
fix(dynmaic group): fix unwanted redirect

### DIFF
--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -648,7 +648,10 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
         if ($getAll) {
             $computers_params['export_all'] = true;
         }
-        return Search::manageParams('Computer', $computers_params);
+
+        $computers_params["reset"] = true;
+        return Search::manageParams('Computer', $computers_params, true, false);
+
     }
 
 

--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -651,7 +651,6 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
 
         $computers_params["reset"] = true;
         return Search::manageParams('Computer', $computers_params, true, false);
-
     }
 
 


### PR DESCRIPTION
Display a ```DeployGroup``` object redirect to ```Computer``` list if default bookmark is set on it.
This PR fix this

Fix : #114