### PR TITLE
feat(task job log): add logs when prepare did not return any target

### DIFF
--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -710,6 +710,11 @@ taskjobs.update_logs = function (data) {
          targets_selector = job_selector + ' .targets_block';
 
          var targets_cpt = 0;
+
+         if(job_v.targets.length === 0) {
+            $(targets_selector).html('The preparation of the task did not return any targets');
+         }
+
          $.each( job_v.targets, function( target_i, target_v) {
             target_id = target_i+ '_' + targets_cpt;
             targets_cpt++;


### PR DESCRIPTION
Add more log when SNMP inventory task (preparation step) did not return any target

![image](https://user-images.githubusercontent.com/7335054/185581383-cb91403c-d2b9-436f-8bc2-72f940e937d4.png)

