### PR TITLE
fix(update): fix last update field migration to core

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -5787,7 +5787,8 @@ function do_computeroperatingsystem_migration($migration)
          5174 => 64, //Kernel name
          5175 => 48, //Kernel version
          5176 => 41, //Service pack
-         5177 => 63  //OS edition
+         5177 => 63, //OS edition
+         5150 => 9   //Last Update
         ];
         foreach ($sopts as $oldid => $newid) {
             $iterator = $DB->request(


### PR DESCRIPTION
```"FusInv - Last inventory"``` have search option ID -> ```5150```

But from GLPI Native Inventory ```Last inventory``` have search option ID ```9```

 This PR handle new ID

Fix #147
