### PR TITLE
fix(menu): do not check right from selfsrevice

### DIFF
--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -34,7 +34,9 @@
 include("../../../inc/includes.php");
 Session::checkLoginUser();
 
-Session::checkRight('plugin_glpiinventory_selfpackage', READ);
+if (!Session::getCurrentInterface() == 'helpdesk') {
+    Session::checkRight('plugin_glpiinventory_selfpackage', READ);
+}
 
 Html::helpHeader(
     __('GLPI Inventory'),

--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -34,7 +34,7 @@
 include("../../../inc/includes.php");
 Session::checkLoginUser();
 
-if (!Session::getCurrentInterface() == 'helpdesk') {
+if (Session::getCurrentInterface() !== 'helpdesk') {
     Session::checkRight('plugin_glpiinventory_selfpackage', READ);
 }
 

--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -2055,7 +2055,7 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
     {
         global $DB;
 
-        if (!Session::getCurrentInterface() == 'helpdesk') {
+        if (Session::getCurrentInterface() !== 'helpdesk') {
             if (!Session::haveRight('plugin_glpiinventory_selfpackage', READ)) {
                 return false;
             }

--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -2055,8 +2055,10 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
     {
         global $DB;
 
-        if (!Session::haveRight('plugin_glpiinventory_selfpackage', READ)) {
-            return false;
+        if (!Session::getCurrentInterface() == 'helpdesk') {
+            if (!Session::haveRight('plugin_glpiinventory_selfpackage', READ)) {
+                return false;
+            }
         }
 
         $table = "glpi_plugin_glpiinventory_deploypackages";

--- a/setup.php
+++ b/setup.php
@@ -316,6 +316,7 @@ function plugin_init_glpiinventory()
             $pfDeployPackage = new PluginGlpiinventoryDeployPackage();
             if ($pfDeployPackage->canUserDeploySelf()) {
                 $PLUGIN_HOOKS['helpdesk_menu_entry']['glpiinventory'] = '/front/deploypackage.public.php';
+                $PLUGIN_HOOKS['helpdesk_menu_entry_icon']['glpiinventory'] = 'ti ti-package';
                 $PLUGIN_HOOKS['add_css']['glpiinventory'][] = "css/views.css";
             }
         }


### PR DESCRIPTION
Add icon menu entry

Do not check ```plugin_glpiinventory_selfpackage``` ```READ``` right from ```helpdesk```

Because GLPI clean ```$_SESSION['glpiactiveprofile']```to keep only 

```php
   /// Helpdesk fields of helpdesk profiles
    public static $helpdesk_rights = [
        'create_ticket_on_login',
        'changetemplates_id',
        'followup',
        'helpdesk_hardware',
        'helpdesk_item_type',
        'knowbase',
        'password_update',
        'personalization',
        'problemtemplates_id',
        'reminder_public',
        'reservation',
        'rssfeed_public',
        'show_group_hardware',
        'task',
        'ticket',
        'ticket_cost',
        'ticket_status',
        'tickettemplates_id',
        'ticketvalidation',
    ];
```
If current user have any package to deploy, menu entry is not added.
See : https://github.com/glpi-project/glpi-inventory-plugin/blob/21e1c540edd90c223b92d5f8a7d6a93ebaf21c50/setup.php#L311-L322


