### PR TITLE
Use native Agent right

### DIFF
--- a/front/agentmodule.form.php
+++ b/front/agentmodule.form.php
@@ -41,7 +41,7 @@ Html::header(
     "agentmodules"
 );
 
-Session::checkRight('plugin_glpiinventory_agent', READ);
+Session::checkRight(PluginGlpiinventoryAgentmodule::$rightname, READ);
 
 $agentmodule = new PluginGlpiinventoryAgentmodule();
 

--- a/inc/agentmodule.class.php
+++ b/inc/agentmodule.class.php
@@ -42,10 +42,11 @@ class PluginGlpiinventoryAgentmodule extends CommonDBTM
 {
    /**
     * The right name for this class
+    * Uses the same right as Agents in native GLPI Inventory
     *
     * @var string
     */
-    public static $rightname = "plugin_glpiinventory_agent";
+    public static $rightname = 'agent';
 
 
    /**


### PR DESCRIPTION
Agent modules should probably use the native "agent" right name.
There was a check in the front file using the plugin-specific right which was removed in 1.0.5.