### PR TITLE
fix(redirect): fix redirect when snmp credential added to IPRange

### DIFF
--- a/front/iprange_snmpcredential.form.php
+++ b/front/iprange_snmpcredential.form.php
@@ -52,10 +52,5 @@ if (isset($_POST["add"])) {
         $_POST['rank'] = $a_data['rank'] + 1;
     }
     $pfIPRange_ConfigSecurity->add($_POST);
-
-    if ($_SESSION['glpibackcreated']) {
-        Html::redirect($pfIPRange_ConfigSecurity->getLinkURL());
-    } else {
-        Html::back();
-    }
+    Html::back();
 }


### PR DESCRIPTION
Prevent blanck page when user try to add ```SNMPCredential``` to ```IPRange```

but introduced by #261 