### PR TITLE
fix(userinteraction): compute default value for behavior on add

### DIFF
--- a/inc/deployuserinteractiontemplate.class.php
+++ b/inc/deployuserinteractiontemplate.class.php
@@ -614,7 +614,9 @@ class PluginGlpiinventoryDeployUserinteractionTemplate extends CommonDropdown
 
     public function prepareInputForAdd($input)
     {
-       //Save params as a json array, ready to be saved in db
+        //Compute default value if needed (for behavior configuration)
+        $input = $this->initializeJsonFields($input);
+        //Save params as a json array, ready to be saved in db
         $input['json'] = $this->saveToJson($input);
         return $input;
     }

--- a/tests/Unit/Deploy/DeployUserinteractionTemplateTest.php
+++ b/tests/Unit/Deploy/DeployUserinteractionTemplateTest.php
@@ -216,7 +216,8 @@ class DeployUserinteractionTemplateTest extends TestCase
              ];
         $this->assertNotNull($interaction->add($tmp));
         $interaction->getFromDB(1);
-        $this->assertEquals('[]', $interaction->fields['json']);
+        $expected = '{"platform":"","timeout":"","buttons":"","icon":"","retry_after":"","nb_max_retry":"","on_timeout":"continue:continue","on_nouser":"continue:continue","on_multiusers":"continue:continue","on_ok":"continue:continue","on_no":"stop:stop","on_yes":"continue:continue","on_cancel":"stop:stop","on_abort":"stop:stop","on_retry":"stop:postpone","on_tryagain":"stop:postpone","on_ignore":"stop:postpone","on_continue":"","on_async":""}';
+        $this->assertEquals($expected, $interaction->fields['json']);
 
         $tmp = ['name'         => 'test2',
               'entities_id'  => 0,
@@ -406,7 +407,7 @@ class DeployUserinteractionTemplateTest extends TestCase
                 'icon'       => PluginGlpiinventoryDeployUserinteractionTemplate::WTS_ICON_QUESTION,
                 'on_timeout' => PluginGlpiinventoryDeployUserinteractionTemplate::BEHAVIOR_CONTINUE_DEPLOY
                ];
-        $expected = '{"icon":"question","on_timeout":"continue:continue"}';
+        $expected = '{"platform":"","timeout":"","buttons":"","icon":"question","retry_after":"","nb_max_retry":"","on_timeout":"continue:continue","on_nouser":"continue:continue","on_multiusers":"continue:continue","on_ok":"continue:continue","on_no":"stop:stop","on_yes":"continue:continue","on_cancel":"stop:stop","on_abort":"stop:stop","on_retry":"stop:postpone","on_tryagain":"stop:postpone","on_ignore":"stop:postpone","on_continue":"","on_async":""}';
         $modified = $template->prepareInputForAdd($input);
         $this->assertEquals($expected, $modified['json']);
     }


### PR DESCRIPTION
If a user create ```UserInteraction```

![image](https://user-images.githubusercontent.com/7335054/206115427-f7488693-4463-4955-a659-9994d04fbd8e.png)

without save data from ```Behavior``` tab

![image](https://user-images.githubusercontent.com/7335054/206115469-a04814bf-9b1a-4dab-9f54-15b7331549b4.png)

some data are missing from databases

```json
{
  "platform": "win32",
  "timeout": "0",
  "buttons": "ok",
  "icon": "none",
  "retry_after": "0",
  "nb_max_retry": "1",

  **//the following items are missing**

  "on_timeout": "continue:continue",
  "on_nouser": "continue:continue",
  "on_multiusers": "continue:continue",
  "on_ok": "continue:continue",
  "on_no": "",
  "on_yes": "",
  "on_cancel": "",
  "on_abort": "",
  "on_retry": "",
  "on_tryagain": "",
  "on_ignore": "",
  "on_continue": ""
}

```

This PR compute default value for ```behaviors``` data on create.

Fix for https://github.com/glpi-project/glpi-inventory-plugin/issues/272
