### PR TITLE
Fix to support agent_base_url with full url to plugin

### DIFF
--- a/inc/agentmodule.class.php
+++ b/inc/agentmodule.class.php
@@ -413,7 +413,7 @@ class PluginGlpiinventoryAgentmodule extends CommonDBTM
                 "Entity " . $entities_id . ", agent base URL: " . $base_url
             );
         } else {
-           // ... else use global GLPI configuration parameter.
+            // ... else use global GLPI configuration parameter.
             global $CFG_GLPI;
             $base_url = $CFG_GLPI['url_base'];
 
@@ -423,9 +423,14 @@ class PluginGlpiinventoryAgentmodule extends CommonDBTM
             );
         }
 
-       // Construct the path to the JSON back from the agent_base_url.
-       // agent_base_url is the initial URL used by the agent
-        return $base_url . $plugin_dir . '/b/' . strtolower($modulename) . '/';
+        // Add plugin_dir only if still not set in agent_base_url
+        if (!preg_match('/(plugins|marketplace)/', $base_url)) {
+            $base_url .= $plugin_dir;
+        }
+
+        // Construct the path to the JSON back from the agent_base_url.
+        // agent_base_url is the initial URL used by the agent
+        return $base_url . '/b/' . strtolower($modulename) . '/';
     }
 
 


### PR DESCRIPTION
Support to set Agent Base URL with the same URL than the one configured in agents like:

![image](https://user-images.githubusercontent.com/12514489/206164931-920fbecc-3f32-45c5-aa28-6d9cb6374acd.png)

This will avoid some old mistakes people does with this configuration when they set there the same URL than the agent one.

Linked ticket: !25732