### PR TITLE
Fix handling of conflicts with "You-Know-Who"

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -441,43 +441,6 @@ function plugin_version_glpiinventory()
  */
 function plugin_glpiinventory_check_prerequisites()
 {
-    global $DB;
-
-    if (!method_exists('Plugin', 'checkVersions')) {
-        $version = rtrim(GLPI_VERSION, '-dev');
-        if (version_compare($version, PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION, 'lt')) {
-            echo "This plugin requires GLPI " . PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION;
-            return false;
-        }
-
-        if (!isset($_SESSION['glpi_plugins'])) {
-            $_SESSION['glpi_plugins'] = [];
-        }
-
-        if (
-            version_compare(GLPI_VERSION, PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION . '-dev', '!=')
-            && version_compare(GLPI_VERSION, PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION, 'lt')
-            || version_compare(GLPI_VERSION, PLUGIN_GLPI_INVENTORY_GLPI_MAX_VERSION, 'ge')
-        ) {
-            if (method_exists('Plugin', 'messageIncompatible')) {
-                echo Plugin::messageIncompatible('core', PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION, PLUGIN_GLPI_INVENTORY_GLPI_MAX_VERSION);
-            } else {
-               // TRANS: %1$s is the minimum GLPI version inclusive, %2$s the maximum version exclusive
-                echo sprintf(
-                    __('Your GLPI version not compatible, require >= %1$s and < %2$s', 'glpiinventory'),
-                    PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION,
-                    PLUGIN_GLPI_INVENTORY_GLPI_MAX_VERSION
-                );
-            }
-            return false;
-        }
-
-        if (!function_exists('finfo_open')) {
-            echo __('fileinfo extension (PHP) is required...', 'glpiinventory');
-            return false;
-        }
-    }
-
     $a_plugins = ['fusinvinventory', 'fusinvsnmp', 'fusinvdeploy', 'fusioninventory'];
     foreach ($a_plugins as $pluginname) {
         if (file_exists(GLPI_ROOT . '/plugins/' . $pluginname)) {
@@ -486,17 +449,6 @@ function plugin_glpiinventory_check_prerequisites()
         }
     }
 
-    return true;
-}
-
-
-/**
- * Check if the config is ok
- *
- * @return boolean
- */
-function plugin_glpiinventory_check_config()
-{
     return true;
 }
 

--- a/setup.php
+++ b/setup.php
@@ -411,7 +411,7 @@ function plugin_version_glpiinventory()
            'shortname'      => 'glpiinventory',
            'version'        => PLUGIN_GLPIINVENTORY_VERSION,
            'license'        => 'AGPLv3+',
-           'oldname'        => 'tracker',
+           'oldname'        => 'fusioninventory',
            'author'         => 'Teclib\'',
            'homepage'       => 'https://github.com/glpi-project/glpi-inventory-plugin',
            'requirements'   => [

--- a/setup.php
+++ b/setup.php
@@ -441,11 +441,16 @@ function plugin_version_glpiinventory()
  */
 function plugin_glpiinventory_check_prerequisites()
 {
-    $a_plugins = ['fusinvinventory', 'fusinvsnmp', 'fusinvdeploy', 'fusioninventory'];
-    foreach ($a_plugins as $pluginname) {
-        if (file_exists(GLPI_ROOT . '/plugins/' . $pluginname)) {
-            printf(__('Please remove folder %s in glpi/plugins/', 'glpiinventory'), $pluginname);
-            return false;
+    if (version_compare(GLPI_VERSION, '10.0.5', '<=')) {
+        $a_plugins = ['fusinvinventory', 'fusinvsnmp', 'fusinvdeploy', 'fusioninventory'];
+        foreach ($a_plugins as $pluginname) {
+            foreach (PLUGINS_DIRECTORIES as $basedir) {
+                $plugindir = $basedir . '/' . $pluginname;
+                if (file_exists($plugindir)) {
+                    printf(__('Please remove %s directory.', 'glpiinventory'), $plugindir);
+                    return false;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
1. Fix the `oldname` property.
2. Ensure that "You-Know-Who" is not present in marketplace directory during prerequisites checks for GLPI <= 10.0.5, but disable this check in GLPI >= 10.0.6.
3. Remove checks done only on GLPI < 9.2 (`!method_exists('Plugin', 'checkVersions')` is always false now).