### PR TITLE
fix(deploygroup_static): fix and harmonize massive action

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -447,14 +447,17 @@ function plugin_glpiinventory_MassiveActions($type)
         case "Computer":
             if (Session::haveRight('plugin_glpiinventory_task', UPDATE)) {
                 $ma["PluginGlpiinventoryTask" . $sep . "target_task"]
-                 = __('Target a task', 'glpiinventory');
+                 = "<i class='ti ti-list-check'></i>" . __('Target a task', 'glpiinventory');
             }
             if (Session::haveRight('plugin_glpiinventory_group', UPDATE)) {
                 $ma["PluginGlpiinventoryDeployGroup" . $sep . "add_to_static_group"]
-                = __('Add to static group', 'glpiinventory');
+                = "<i class='ti ti-devices-pc'></i>" . __('Add to static group', 'glpiinventory');
+                $ma["PluginGlpiinventoryDeployGroup" . $sep . "exclude_from_static_group"]
+                = "<i class='ti ti-devices-pc'></i>" . __('Remove from static group', 'glpiinventory');
             }
             break;
     }
+
     return $ma;
 }
 

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -3,7 +3,7 @@
 /**
  * ---------------------------------------------------------------------
  * GLPI Inventory Plugin
- * Copyright (C) 2021 Teclib' and contributors.
+ * Copyright (C) 2021-2023 Teclib' and contributors.
  *
  * http://glpi-project.org
  *

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -8,7 +8,7 @@
  * http://glpi-project.org
  *
  * based on FusionInventory for GLPI
- * Copyright (C) 2010-2021 by the FusionInventory Development Team.
+ * Copyright (C) 2010-2023 by the FusionInventory Development Team.
  *
  * ---------------------------------------------------------------------
  *

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -1,47 +1,34 @@
 <?php
 
 /**
- * FusionInventory
+ * ---------------------------------------------------------------------
+ * GLPI Inventory Plugin
+ * Copyright (C) 2021 Teclib' and contributors.
  *
- * Copyright (C) 2010-2022 by the FusionInventory Development Team.
+ * http://glpi-project.org
  *
- * http://www.fusioninventory.org/
- * https://github.com/fusioninventory/fusioninventory-for-glpi
- * http://forge.fusioninventory.org/
+ * based on FusionInventory for GLPI
+ * Copyright (C) 2010-2021 by the FusionInventory Development Team.
  *
- * ------------------------------------------------------------------------
+ * ---------------------------------------------------------------------
  *
  * LICENSE
  *
- * This file is part of FusionInventory project.
+ * This file is part of GLPI Inventory Plugin.
  *
- * FusionInventory is free software: you can redistribute it and/or modify
+ * GLPI Inventory Plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * FusionInventory is distributed in the hope that it will be useful,
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with FusionInventory. If not, see <http://www.gnu.org/licenses/>.
- *
- * ------------------------------------------------------------------------
- *
- * This file is used to manage the search in groups (static and dynamic).
- *
- * ------------------------------------------------------------------------
- *
- * @package   FusionInventory
- * @author    David Durieux
- * @copyright Copyright (c) 2010-2022 FusionInventory team
- * @license   AGPL License 3.0 or (at your option) any later version
- *            http://www.gnu.org/licenses/agpl-3.0-standalone.html
- * @link      http://www.fusioninventory.org/
- * @link      https://github.com/fusioninventory/fusioninventory-for-glpi
- *
+ * along with GLPI Inventory Plugin. If not, see <https://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
  */
 
 if (!defined('GLPI_ROOT')) {

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -149,7 +149,7 @@ class PluginGlpiinventoryComputer extends Computer
                         $group_item->deleteByCriteria(['items_id' => $key,
                                                        'itemtype' => 'Computer',
                                                        'plugin_glpiinventory_deploygroups_id'
-                                                          => $_POST['id']])
+                                                          => $_POST['item_items_id']])
                     ) {
                         $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
                     } else {

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * FusionInventory
+ *
+ * Copyright (C) 2010-2022 by the FusionInventory Development Team.
+ *
+ * http://www.fusioninventory.org/
+ * https://github.com/fusioninventory/fusioninventory-for-glpi
+ * http://forge.fusioninventory.org/
+ *
+ * ------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of FusionInventory project.
+ *
+ * FusionInventory is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FusionInventory is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with FusionInventory. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * ------------------------------------------------------------------------
+ *
+ * This file is used to manage the search in groups (static and dynamic).
+ *
+ * ------------------------------------------------------------------------
+ *
+ * @package   FusionInventory
+ * @author    David Durieux
+ * @copyright Copyright (c) 2010-2022 FusionInventory team
+ * @license   AGPL License 3.0 or (at your option) any later version
+ *            http://www.gnu.org/licenses/agpl-3.0-standalone.html
+ * @link      http://www.fusioninventory.org/
+ * @link      https://github.com/fusioninventory/fusioninventory-for-glpi
+ *
+ */
+
+if (!defined('GLPI_ROOT')) {
+    die("Sorry. You can't access directly to this file");
+}
+
+/**
+ * Manage the search in groups (static and dynamic).
+ */
+class PluginGlpiinventoryComputer extends Computer
+{
+   /**
+    * The right name for this class
+    *
+    * @var string
+    */
+    public static $rightname = "plugin_glpiinventory_group";
+
+
+    public function rawSearchOptions()
+    {
+        $computer = new Computer();
+        $options  = $computer->rawSearchOptions();
+
+        $plugin = new Plugin();
+        if ($plugin->isInstalled('fields')) {
+            if ($plugin->isActivated('fields')) {
+                // Include Fields hook from correct installation folder (marketplace or plugins)
+                include_once(Plugin::GetPhpDir("fields") . "/hook.php");
+                $options['fields_plugin'] = [
+                 'id'   => 'fields_plugin',
+                 'name' => __('Plugin fields')
+                ];
+                $fieldsoptions =  plugin_fields_getAddSearchOptions('Computer');
+                foreach ($fieldsoptions as $id => $data) {
+                    $data['id'] = $id;
+                    $options[$id] = $data;
+                }
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Return the table used to store this object
+     *
+     * @param string $classname Force class (to avoid late_binding on inheritance)
+     *
+     * @return string
+     **/
+    public static function getTable($classname = null)
+    {
+        return 'glpi_computers';
+    }
+
+
+   /**
+    * Define the standard massive actions to hide for this class
+    *
+    * @return array list of massive actions to hide
+    */
+    public function getForbiddenStandardMassiveAction()
+    {
+
+        $forbidden   = parent::getForbiddenStandardMassiveAction();
+        $forbidden[] = 'update';
+        $forbidden[] = 'add';
+        $forbidden[] = 'delete';
+        return $forbidden;
+    }
+
+
+   /**
+    * Execution code for massive action
+    *
+    * @param object $ma MassiveAction instance
+    * @param object $item item on which execute the code
+    * @param array $ids list of ID on which execute the code
+    */
+    public static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item, array $ids)
+    {
+
+        $group_item = new PluginGlpiinventoryDeployGroup_Staticdata();
+        switch ($ma->getAction()) {
+            case 'add':
+                foreach ($ids as $key) {
+                    if ($item->can($key, UPDATE)) {
+                        if (
+                            !countElementsInTable(
+                                $group_item->getTable(),
+                                [
+                                'plugin_glpiinventory_deploygroups_id' => $_POST['id'],
+                                'itemtype'                               => 'Computer',
+                                'items_id'                               => $key,
+                                ]
+                            )
+                        ) {
+                            $group_item->add([
+                            'plugin_glpiinventory_deploygroups_id'
+                            => $_POST['id'],
+                            'itemtype' => 'Computer',
+                            'items_id' => $key]);
+                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                        } else {
+                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                        }
+                    } else {
+                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                        $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
+                    }
+                }
+                return;
+
+            case 'deleteitem':
+                foreach ($ids as $key) {
+                    if (
+                        $group_item->deleteByCriteria(['items_id' => $key,
+                                                       'itemtype' => 'Computer',
+                                                       'plugin_glpiinventory_deploygroups_id'
+                                                          => $_POST['id']])
+                    ) {
+                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                    } else {
+                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                    }
+                }
+        }
+    }
+
+
+   /**
+    * Display form related to the massive action selected
+    *
+    * @param object $ma MassiveAction instance
+    * @return boolean
+    */
+    public static function showMassiveActionsSubForm(MassiveAction $ma)
+    {
+        if ($ma->getAction() == 'add') {
+            echo "<br><br>" . Html::submit(
+                _x('button', 'Add'),
+                ['name' => 'massiveaction']
+            );
+            return true;
+        }
+        return parent::showMassiveActionsSubForm($ma);
+    }
+}

--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -275,12 +275,12 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
                     }
                 }
                 break;
-            case 'remove_from_static_group':
+            case 'exclude_from_static_group':
                 if ($item->getType() == 'Computer') {
                     $group_item = new PluginGlpiinventoryDeployGroup_Staticdata();
                     foreach ($ids as $id) {
                         if (
-                            !countElementsInTable(
+                            countElementsInTable(
                                 $group_item->getTable(),
                                 [
                                 'plugin_glpiinventory_deploygroups_id' => $_POST['plugin_glpiinventory_deploygroups_id'],

--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -221,6 +221,7 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
     {
         switch ($ma->getAction()) {
             case 'add_to_static_group':
+            case 'exclude_from_static_group':
                 Dropdown::show(
                     'PluginGlpiinventoryDeployGroup',
                     ['condition' => ['type' => PluginGlpiinventoryDeployGroup::STATIC_GROUP]]
@@ -268,6 +269,34 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
                             'items_id' => $id];
                             $group_item->add($values);
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        } else {
+                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        }
+                    }
+                }
+                break;
+            case 'remove_from_static_group':
+                if ($item->getType() == 'Computer') {
+                    $group_item = new PluginGlpiinventoryDeployGroup_Staticdata();
+                    foreach ($ids as $id) {
+                        if (
+                            !countElementsInTable(
+                                $group_item->getTable(),
+                                [
+                                'plugin_glpiinventory_deploygroups_id' => $_POST['plugin_glpiinventory_deploygroups_id'],
+                                'itemtype'                               => 'Computer',
+                                'items_id'                               => $id,
+                                ]
+                            )
+                        ) {
+                            $values = [
+                            'plugin_glpiinventory_deploygroups_id' => $_POST['plugin_glpiinventory_deploygroups_id'],
+                            'itemtype' => 'Computer',
+                            'items_id' => $id];
+                            if ($group_item->getFromDBByCrit($values)) {
+                                $group_item->deleteByCriteria($values);
+                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            }
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                         }

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -167,7 +167,7 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
 
        //Add extra parameters for massive action display : only the Add action should be displayed
         $search_params['massiveactionparams']['extraparams']['id']                    = $item->getID();
-        $search_params['massiveactionparams']['extraparams']['specific_actions']['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'] = __('Add to associated items of the group', 'glpiinventory');
+        $search_params['massiveactionparams']['extraparams']['specific_actions']['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'] = __('Add to static group', 'glpiinventory');
         $search_params['massiveactionparams']['extraparams']['massive_action_fields'] = ['action', 'id'];
 
         $data = Search::prepareDatasForSearch('PluginGlpiinventoryComputer', $search_params);
@@ -227,7 +227,7 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         Html::openMassiveActionsForm('mass'.$mass_class.$rand);
         $massiveactionparams= ['num_displayed' => min($_SESSION['glpilist_limit'], $number),
                     'item' => $item,
-                    'specific_actions' => ['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'deleteitem' => _x('button', 'Remove')],
+                    'specific_actions' => ['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'deleteitem' => _x('button', __('Remove from static group', 'glpiinventory'))],
                     'container' => 'mass'.$mass_class.$rand,
                     'massive_action_fields' => ['action', 'id'],
                     ];

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -210,25 +210,24 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
             'SELECT' => '*',
             'FROM'   => self::getTable(),
             'WHERE'  => ['plugin_glpiinventory_deploygroups_id' => $item->getID()],
-         ];
+        ];
 
-         $datas = [];
-         $iterator = $DB->request($params);
-         foreach ($iterator as $data) {
+        $datas = [];
+        $iterator = $DB->request($params);
+        foreach ($iterator as $data) {
             $datas[] = $data;
-         }
-         $number = count($datas);
-
+        }
+        $number = count($datas);
 
         echo "<div class='spaced'>";
         echo "<div class='spaced'>";
 
         $mass_class = "PluginGlpiinventoryComputer";
-        Html::openMassiveActionsForm('mass'.$mass_class.$rand);
-        $massiveactionparams= ['num_displayed' => min($_SESSION['glpilist_limit'], $number),
+        Html::openMassiveActionsForm('mass' . $mass_class . $rand);
+        $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], $number),
                     'item' => $item,
                     'specific_actions' => ['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'deleteitem' => _x('button', __('Remove from static group', 'glpiinventory'))],
-                    'container' => 'mass'.$mass_class.$rand,
+                    'container' => 'mass' . $mass_class . $rand,
                     'massive_action_fields' => ['action', 'id'],
                     ];
         Html::showMassiveActions($massiveactionparams);
@@ -239,21 +238,20 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $header_bottom = '';
         $header_end    = '';
 
-        $header_top    .= "<th width='10'>".Html::getCheckAllAsCheckbox('mass'.$mass_class.$rand);
+        $header_top    .= "<th width='10'>" . Html::getCheckAllAsCheckbox('mass' . $mass_class . $rand);
         $header_top    .= "</th>";
-        $header_bottom .= "<th width='10'>".Html::getCheckAllAsCheckbox('mass'.$mass_class.$rand);
+        $header_bottom .= "<th width='10'>" . Html::getCheckAllAsCheckbox('mass' . $mass_class . $rand);
         $header_bottom .=  "</th>";
 
-        $header_end .= "<th>".__('Name')."</th>";
-        $header_end .= "<th>".__('Automatic inventory')."</th>";
-        $header_end .= "<th>".Entity::getTypeName(1)."</th>";
-        $header_end .= "<th>".__('Serial number')."</th>";
-        $header_end .= "<th>".__('Inventory number')."</th>";
+        $header_end .= "<th>" . __('Name') . "</th>";
+        $header_end .= "<th>" . __('Automatic inventory') . "</th>";
+        $header_end .= "<th>" . Entity::getTypeName(1) . "</th>";
+        $header_end .= "<th>" . __('Serial number') . "</th>";
+        $header_end .= "<th>" . __('Inventory number') . "</th>";
         $header_end .= "</tr>";
-        echo $header_begin.$header_top.$header_end;
+        echo $header_begin . $header_top . $header_end;
 
         foreach ($datas as $data) {
-
             $computer = new Computer();
             $computer->getFromDB($data["items_id"]);
             $linkname = $computer->fields["name"];
@@ -262,27 +260,29 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
                 $linkname = sprintf(__('%1$s (%2$s)'), $linkname, $computer->fields["id"]);
             }
             $link = $itemtype::getFormURLWithID($computer->fields["id"]);
-            $name = "<a href=\"".$link."\">".$linkname."</a>";
+            $name = "<a href=\"" . $link . "\">" . $linkname . "</a>";
             echo "<tr class='tab_bg_1'>";
 
             echo "<td width='10'>";
             Html::showMassiveActionCheckBox($mass_class, $data["items_id"]);
             echo "</td>";
 
-            echo "<td ".
-                ((isset($computer->fields['is_deleted']) && $computer->fields['is_deleted'])?"class='tab_bg_2_2'":"").
-                ">".$name."</td>";
-            echo "<td>".Dropdown::getYesNo($computer->fields['is_dynamic'])."</td>";
-            echo "<td>".Dropdown::getDropdownName("glpi_entities",
-                                                                $computer->fields['entities_id']);
+            echo "<td " .
+                ((isset($computer->fields['is_deleted']) && $computer->fields['is_deleted']) ? "class='tab_bg_2_2'" : "") .
+                ">" . $name . "</td>";
+            echo "<td>" . Dropdown::getYesNo($computer->fields['is_dynamic']) . "</td>";
+            echo "<td>" . Dropdown::getDropdownName(
+                "glpi_entities",
+                $computer->fields['entities_id']
+            );
             echo "</td>";
-            echo "<td>".
-                    (isset($computer->fields["serial"])? "".$computer->fields["serial"]."" :"-")."</td>";
-            echo "<td>".
-                    (isset($computer->fields["otherserial"])? "".$computer->fields["otherserial"]."" :"-")."</td>";
+            echo "<td>" .
+                    (isset($computer->fields["serial"]) ? "" . $computer->fields["serial"] . "" : "-") . "</td>";
+            echo "<td>" .
+                    (isset($computer->fields["otherserial"]) ? "" . $computer->fields["otherserial"] . "" : "-") . "</td>";
             echo "</tr>";
         }
-        echo $header_begin.$header_bottom.$header_end;
+        echo $header_begin . $header_bottom . $header_end;
 
         echo "</table>";
         if ($number) {

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -167,17 +167,17 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
 
        //Add extra parameters for massive action display : only the Add action should be displayed
         $search_params['massiveactionparams']['extraparams']['id']                    = $item->getID();
-        $search_params['massiveactionparams']['extraparams']['custom_action']         = 'add_to_group';
+        $search_params['massiveactionparams']['extraparams']['specific_actions']['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'] = __('Add to associated items of the group', 'glpiinventory');
         $search_params['massiveactionparams']['extraparams']['massive_action_fields'] = ['action', 'id'];
 
-        $data = Search::prepareDatasForSearch('Computer', $search_params);
+        $data = Search::prepareDatasForSearch('PluginGlpiinventoryComputer', $search_params);
         $data['itemtype'] = 'Computer';
         Search::constructSQL($data);
 
        // Use our specific constructDatas function rather than Glpi function
         PluginGlpiinventorySearch::constructDatas($data);
         $data['search']['target'] = PluginGlpiinventoryDeployGroup::getSearchEngineTargetURL($item->getID(), false);
-        $data['itemtype'] = 'Computer';
+        $data['itemtype'] = 'PluginGlpiinventoryComputer';
         Search::displayData($data);
     }
 
@@ -188,21 +188,21 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
     public static function showResults()
     {
         if (
-            isset($_SESSION['glpisearch']['Computer'])
-              && isset($_SESSION['glpisearch']['Computer']['show_results'])
+            isset($_SESSION['glpisearch']['PluginGlpiinventoryComputer'])
+              && isset($_SESSION['glpisearch']['PluginGlpiinventoryComputer']['show_results'])
         ) {
-            $computers_params = $_SESSION['glpisearch']['Computer'];
+            $computers_params = $_SESSION['glpisearch']['PluginGlpiinventoryComputer'];
         }
         $computers_params['metacriteria'] = [];
         $computers_params['criteria'][]   = ['searchtype' => 'equals',
                                                 'value' => $_GET['id'],
                                                 'field' => 5171];
 
-        $search_params = Search::manageParams('Computer', $computers_params);
+        $search_params = Search::manageParams('PluginGlpiinventoryComputer', $computers_params);
 
        //Add extra parameters for massive action display : only the Delete action should be displayed
         $search_params['massiveactionparams']['extraparams']['id'] = $_GET['id'];
-        $search_params['massiveactionparams']['extraparams']['custom_action'] = 'delete_from_group';
+        $search_params['massiveactionparams']['extraparams']['specific_actions']['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'deleteitem'] = __('Remove from associated items of the group', 'glpiinventory');
         $search_params['massiveactionparams']['extraparams']['massive_action_fields'] = ['action', 'id'];
         $data = Search::prepareDatasForSearch('Computer', $search_params);
 
@@ -212,7 +212,7 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
        // Use our specific constructDatas function rather than Glpi function
         PluginGlpiinventorySearch::constructDatas($data);
         $data['search']['target'] = PluginGlpiinventoryDeployGroup::getSearchEngineTargetURL($_GET['id'], false);
-        $data['itemtype'] = 'Computer';
+        $data['itemtype'] = 'PluginGlpiinventoryComputer';
         Search::displayData($data);
     }
 

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -178,7 +178,23 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         PluginGlpiinventorySearch::constructDatas($data);
         $data['search']['target'] = PluginGlpiinventoryDeployGroup::getSearchEngineTargetURL($item->getID(), false);
         $data['itemtype'] = 'PluginGlpiinventoryComputer';
+        $limit_backup = $_SESSION['glpilist_limit'];
+        $_SESSION['glpilist_limit'] = 200;
         Search::displayData($data);
+        $_SESSION['glpilist_limit'] = $limit_backup;
+
+        //remove trashbin switch
+        echo Html::scriptBlock("
+            $(document).ready(
+                function() {
+                    $('label.form-switch').hide();
+                    $('#dropdown-export').hide();
+                    $('button.show_displaypreference_modal').hide();
+                    $('#massformPluginGlpiinventoryComputer').find('table:first').removeClass('search-results');
+                    $('span.search-limit').html('');
+                }
+            );
+        ");
     }
 
 


### PR DESCRIPTION
Actually specific massives actions ```add to group``` or ```remove from group``` are not displayed

![image](https://user-images.githubusercontent.com/7335054/217855070-06ffffbb-8fe8-47af-9815-ff8377b68e9f.png)


Now : 

From ```criteria``` tab we can add computer to group easily
![image](https://user-images.githubusercontent.com/7335054/217854441-568dea7f-3c03-40ad-9cba-c1b9dd303a8e.png)

From ```Associated elements``` tab we can delete computer to group easily
![image](https://user-images.githubusercontent.com/7335054/217854610-3add66de-2fe0-42cf-9d6a-d9860ee2b516.png)

This PR try to harmonize massives actions from computer by adding ```exclude_from_group```  (```add_to_group``` already present```)

![image](https://user-images.githubusercontent.com/7335054/217855411-e4df1dc5-6862-4c18-b354-694987b69c73.png)


fix : https://github.com/glpi-project/glpi-inventory-plugin/issues/308