### PR TITLE
fix(dashboard): use 'contains' instead of 'equals'

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -136,8 +136,8 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
             'apply_filters' =>  [
                 'link'          => 'AND',
                 'field'         => 42,
-                'searchtype'    => 'equals',
-                'value'         => 1,
+                'searchtype'    => 'contains',
+                'value'         => 'GLPI Native Inventory',
                 ]
             ],
         'printer'         => [
@@ -146,8 +146,8 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
             'apply_filters' =>  [
                 'link'          => 'AND',
                 'field'         => 72,
-                'searchtype'    => 'equals',
-                'value'         => 1,
+                'searchtype'    => 'contains',
+                'value'         => 'GLPI Native Inventory',
                 ]
             ],
         'networkequipement'         => [
@@ -156,8 +156,8 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
             'apply_filters' =>  [
                 'link'          => 'AND',
                 'field'         => 72,
-                'searchtype'    => 'equals',
-                'value'         => 1,
+                'searchtype'    => 'contains',
+                'value'         => 'GLPI Native Inventory',
                 ]
             ],
         'phone'         => [
@@ -166,8 +166,8 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
             'apply_filters' =>  [
                 'link'          => 'AND',
                 'field'         => 72,
-                'searchtype'    => 'equals',
-                'value'         => 1,
+                'searchtype'    => 'contains',
+                'value'         => 'GLPI Native Inventory',
                 ]
             ]
     ];


### PR DESCRIPTION
Prevent bad search with hardcoded ID (```AutoUpdateSystem```)

(usefull if user deletes the original ```AutoUpdateSystem```)

Use ```contains``` instead of ```equal```

Fix : https://github.com/glpi-project/glpi-inventory-plugin/issues/323