### PR TITLE
fix(TU):fix entities_id check on transfer step

### DIFF
--- a/tests/Integration/ComputerEntityTest.php
+++ b/tests/Integration/ComputerEntityTest.php
@@ -240,7 +240,7 @@ class ComputerEntityTest extends TestCase
 
         //the agent must follow / keep the PC entity (even if transfer is disallowed)
         //due to https://github.com/glpi-project/glpi/pull/14254
-        $this->agentEntity($computer->fields['id'], 2, 'Agent must stay with entity 2');
+        $this->agentEntity($computer->fields['id'], 2, 'Agent follows computer on entity 2');
     }
 
 

--- a/tests/Integration/ComputerEntityTest.php
+++ b/tests/Integration/ComputerEntityTest.php
@@ -238,7 +238,9 @@ class ComputerEntityTest extends TestCase
         $computer->getFromDBByCrit(['serial' => 'xxyyzz']);
         $this->assertEquals(2, $computer->fields['entities_id'], 'Computer must not be transferred');
 
-        $this->agentEntity($computer->fields['id'], 1, 'Agent must stay with entity 1');
+        //the agent must follow / keep the PC entity (even if transfer is disallowed)
+        //due to https://github.com/glpi-project/glpi/pull/14254
+        $this->agentEntity($computer->fields['id'], 2, 'Agent must stay with entity 2');
     }
 
 


### PR DESCRIPTION
The agent must follow / keep the PC entity (even if transfer is disallowed)
Due to https://github.com/glpi-project/glpi/pull/14254
