### PR TITLE
fix(migration): handle lost value last_boot, remote_addr, last_inventory_update

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -3104,12 +3104,16 @@ function do_biosascomponentmigration()
         $DB->tableExists('glpi_plugin_glpiinventory_inventorycomputercomputers') &&
         $DB->fieldExists('glpi_plugin_glpiinventory_inventorycomputercomputers', 'remote_addr')
     ) {
-        //retrieve exiting
-        $query = "SELECT computers_id, remote_addr
-                    FROM glpi_plugin_glpiinventory_inventorycomputercomputers";
-        $result = $DB->query($query);
 
-        while ($data = $DB->fetchArray($result)) {
+        $computers_iterator = $DB->request([
+            'SELECT' => [
+                'computers_id',
+                'remote_addr'
+            ],
+            'FROM' => 'glpi_plugin_glpiinventory_inventorycomputercomputers'
+        ]);
+
+        foreach ($computers_iterator as $data) {
             $computer = new Computer();
             if ($computer->getFromDB($data['computers_id'])) {
                 $agent = $computer->getInventoryAgent();
@@ -3133,12 +3137,16 @@ function do_biosascomponentmigration()
         $DB->fieldExists('glpi_plugin_glpiinventory_inventorycomputercomputers', 'last_boot') &&
         $DB->fieldExists('glpi_plugin_glpiinventory_inventorycomputercomputers', 'last_inventory_update')
     ) {
-        //retrieve exiting
-        $query = "SELECT computers_id, last_boot, last_inventory_update
-                    FROM glpi_plugin_glpiinventory_inventorycomputercomputers";
-        $result = $DB->query($query);
+        $computers_iterator = $DB->request([
+            'SELECT' => [
+                'computers_id',
+                'last_boot',
+                'last_inventory_update'
+            ],
+            'FROM' => 'glpi_plugin_glpiinventory_inventorycomputercomputers'
+        ]);
 
-        while ($data = $DB->fetchArray($result)) {
+        foreach ($computers_iterator as $data) {
             $computer = new Computer();
             if ($computer->getFromDB($data['computers_id'])) {
                 $input = [

--- a/install/update.php
+++ b/install/update.php
@@ -3125,10 +3125,19 @@ function do_biosascomponentmigration()
                 //handle last_inventory_update and last_boot
                 $input_computer = [
                     'id'                    => $computer->fields['id'],
-                    'last_boot'             => $data['last_boot'] ?? null,
-                    'last_inventory_update' => $data['last_inventory_update'] ?? null
                 ];
-                $computer->update($input_computer);
+
+                if (!empty($data['last_boot'])) {
+                    $input_computer['last_boot'] = $data['last_boot'];
+                }
+
+                if (!empty($data['last_inventory_update'])) {
+                    $input_computer['last_inventory_update'] = $data['last_inventory_update'];
+                }
+
+                if (count($input_computer) > 1) {
+                    $computer->update($input_computer);
+                }
 
                 //handle remote_addr
                 $agent = $computer->getInventoryAgent();

--- a/install/update.php
+++ b/install/update.php
@@ -3107,7 +3107,6 @@ function do_biosascomponentmigration()
         $DB->fieldExists('glpi_plugin_glpiinventory_inventorycomputercomputers', 'last_boot') &&
         $DB->fieldExists('glpi_plugin_glpiinventory_inventorycomputercomputers', 'last_inventory_update')
     ) {
-
         $computers_iterator = $DB->request([
             'SELECT' => [
                 'computers_id',
@@ -3121,7 +3120,6 @@ function do_biosascomponentmigration()
         foreach ($computers_iterator as $data) {
             $computer = new Computer();
             if ($computer->getFromDB($data['computers_id'])) {
-
                 //handle last_inventory_update and last_boot
                 $input_computer = [
                     'id'                    => $computer->fields['id'],

--- a/install/update.php
+++ b/install/update.php
@@ -3139,7 +3139,7 @@ function do_biosascomponentmigration()
 
                 //handle remote_addr
                 $agent = $computer->getInventoryAgent();
-                if (!is_null($agent) && !empty($data['remote_addr'])) {
+                if (!is_null($agent) && !empty($data['remote_addr']) && empty($agent->fields['remote_addr'])) {
                     $remote_ip = new IPAddress($data['remote_addr']);
                     if ($remote_ip->is_valid()) {
                         $input_agent = [

--- a/install/update.php
+++ b/install/update.php
@@ -3099,6 +3099,69 @@ function do_biosascomponentmigration()
 {
     global $DB;
 
+    //Agent data migration -> remote_addr
+    if (
+        $DB->tableExists('glpi_plugin_glpiinventory_inventorycomputercomputers') &&
+        $DB->fieldExists('glpi_plugin_glpiinventory_inventorycomputercomputers', 'remote_addr')
+    ) {
+        //retrieve exiting
+        $query = "SELECT computers_id, remote_addr
+                    FROM glpi_plugin_glpiinventory_inventorycomputercomputers";
+        $result = $DB->query($query);
+
+        while ($data = $DB->fetchArray($result)) {
+            $computer = new Computer();
+            if ($computer->getFromDB($data['computers_id'])) {
+                $agent = $computer->getInventoryAgent();
+                if (!is_null($agent) && !empty($data['remote_addr'])) {
+                    $remote_ip = new IPAddress($data['remote_addr']);
+                    if ($remote_ip->is_valid()) {
+                        $input = [
+                            'id' => $agent->fields['id'],
+                            'remote_addr' => $remote_ip->getTextual()
+                        ];
+                        $agent->update($input);
+                    }
+                }
+            }
+        }
+    }
+
+    //Agent data migration -> last_boot / last_inventory_update
+    if (
+        $DB->tableExists('glpi_plugin_glpiinventory_inventorycomputercomputers') &&
+        $DB->fieldExists('glpi_plugin_glpiinventory_inventorycomputercomputers', 'last_boot') &&
+        $DB->fieldExists('glpi_plugin_glpiinventory_inventorycomputercomputers', 'last_inventory_update')
+    ) {
+        //retrieve exiting
+        $query = "SELECT computers_id, last_boot, last_inventory_update
+                    FROM glpi_plugin_glpiinventory_inventorycomputercomputers";
+        $result = $DB->query($query);
+
+        while ($data = $DB->fetchArray($result)) {
+            $computer = new Computer();
+            if ($computer->getFromDB($data['computers_id'])) {
+                $input = [
+                    'id' => $computer->fields['id'],
+                ];
+
+                //migrate last_boot date
+                if (!empty($data['last_boot'])) {
+                    $input['last_boot'] = $data['last_boot'];
+                }
+
+                //migrate last_inventory_update date
+                if (!empty($data['last_inventory_update'])) {
+                    $input['last_inventory_update'] = $data['last_inventory_update'];
+                }
+
+                if (count($input) > 1) {
+                    $computer->update($input);
+                }
+            }
+        }
+    }
+
    //BIOS as a component
     if (
         $DB->tableExists('glpi_plugin_glpiinventory_inventorycomputercomputers') &&


### PR DESCRIPTION
Some data are lost during migration

- ```last_boot```
- ```last_inventory_update```
- ```remote_addr```

This PR prevent this