### PR TITLE
fix(migration): handle lost value last_boot, remote_addr

### DIFF
--- a/install/update.native.php
+++ b/install/update.native.php
@@ -296,11 +296,26 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
             INNER JOIN (
               SELECT
                 `computers_id`,
-                `last_inventory_update`
+                `last_inventory_update`,
+                `last_boot`
               FROM `glpi_plugin_glpiinventory_inventorycomputercomputers`
           ) AS `plugin_computers` ON `plugin_computers`.`computers_id` = `computers`.`id`
           SET
-              `computers`.`last_inventory_update` = `plugin_computers`.`last_inventory_update`
+          `computers`.`last_inventory_update` = `plugin_computers`.`last_inventory_update`,
+          `computers`.`last_boot` = `plugin_computers`.`last_boot`
+          ;"
+        );
+
+        $DB->queryOrDie(
+            "UPDATE `glpi_agents` AS `agents`
+            INNER JOIN (
+              SELECT
+                `computers_id`,
+                `remote_addr`
+              FROM `glpi_plugin_glpiinventory_inventorycomputercomputers`
+          ) AS `plugin_computers` ON `plugin_computers`.`computers_id` = `agents`.`items_id` AND `agents`.`itemtype` = 'Computer'
+          SET
+          `agents`.`remote_addr` = `plugin_computers`.`remote_addr`
           ;"
         );
         $migration->dropTable('glpi_plugin_glpiinventory_inventorycomputercomputers');

--- a/install/update.native.php
+++ b/install/update.native.php
@@ -296,14 +296,26 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
             INNER JOIN (
               SELECT
                 `computers_id`,
-                `last_inventory_update`,
+                `last_inventory_update`
+              FROM `glpi_plugin_glpiinventory_inventorycomputercomputers`
+          ) AS `plugin_computers` ON `plugin_computers`.`computers_id` = `computers`.`id`
+          SET
+          `computers`.`last_inventory_update` = `plugin_computers`.`last_inventory_update`
+          ;"
+        );
+
+        $DB->queryOrDie(
+            "UPDATE `glpi_computers` AS `computers`
+            INNER JOIN (
+              SELECT
+                `computers_id`,
                 `last_boot`
               FROM `glpi_plugin_glpiinventory_inventorycomputercomputers`
           ) AS `plugin_computers` ON `plugin_computers`.`computers_id` = `computers`.`id`
           SET
-          `computers`.`last_inventory_update` = `plugin_computers`.`last_inventory_update`,
           `computers`.`last_boot` = `plugin_computers`.`last_boot`
-          ;"
+          ;
+          WHERE `computers`.`last_boot` IS NULL"
         );
 
         $DB->queryOrDie(
@@ -316,6 +328,7 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
           ) AS `plugin_computers` ON `plugin_computers`.`computers_id` = `agents`.`items_id` AND `agents`.`itemtype` = 'Computer'
           SET
           `agents`.`remote_addr` = `plugin_computers`.`remote_addr`
+          WHERE `agents`.`remote_addr` IS NULL
           ;"
         );
         $migration->dropTable('glpi_plugin_glpiinventory_inventorycomputercomputers');

--- a/install/update.native.php
+++ b/install/update.native.php
@@ -301,7 +301,7 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
           ) AS `plugin_computers` ON `plugin_computers`.`computers_id` = `computers`.`id`
           SET
           `computers`.`last_inventory_update` = `plugin_computers`.`last_inventory_update`
-          ;"
+          WHERE `computers`.`last_inventory_update` IS NULL;"
         );
 
         $DB->queryOrDie(
@@ -314,8 +314,8 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
           ) AS `plugin_computers` ON `plugin_computers`.`computers_id` = `computers`.`id`
           SET
           `computers`.`last_boot` = `plugin_computers`.`last_boot`
-          ;
-          WHERE `computers`.`last_boot` IS NULL"
+          WHERE `computers`.`last_boot` IS NULL
+          ;"
         );
 
         $DB->queryOrDie(
@@ -328,7 +328,7 @@ function pluginGlpiinventoryUpdateNative($current_version, $migrationname = 'Mig
           ) AS `plugin_computers` ON `plugin_computers`.`computers_id` = `agents`.`items_id` AND `agents`.`itemtype` = 'Computer'
           SET
           `agents`.`remote_addr` = `plugin_computers`.`remote_addr`
-          WHERE `agents`.`remote_addr` IS NULL
+          WHERE `agents`.`remote_addr` IS NULL OR `agents`.`remote_addr` = ''
           ;"
         );
         $migration->dropTable('glpi_plugin_glpiinventory_inventorycomputercomputers');


### PR DESCRIPTION
Maybe e better solution for  https://github.com/glpi-project/glpi-inventory-plugin/pull/362

Some data are lost during migration

| Table => Row  | To  | Table => row  | is migrated  |
|---|---|---|---|
| glpi_plugin_glpiinventory_inventorycomputercomputers => last_inventory_update  | =>  |  glpi_computers => last_inventory_update | :ok: |
| glpi_plugin_glpiinventory_inventorycomputercomputers => last_boot  |  =>  | glpi_computers => last_boot  | :x: |
| glpi_plugin_glpiinventory_agents => last_contact | => | glpi_agent => last_contact | :ok: 
| glpi_plugin_glpiinventory_agents => remote_addr | => | glpi_agent => remote_addr | :x: |


This PR fix this
