### PR TITLE
fix not null in query

### DIFF
--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -1209,7 +1209,7 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
             ],
             'WHERE' => array_merge(
                 [
-                    'task.id' => ['!=', null],
+                    'NOT' => ['task.id' => null],
                 ],
                 $active_task,
                 $tasks_list,


### PR DESCRIPTION
task.id != NULL results in no task jobs being returned on the Tasks > Monitoring / Logs screen. The original raw SQL had `IS NOT NULL` being used. As far as I can tell, there is no use for `!= NULL` and it is not equivalent.