### PR TITLE
fix(migration): rename column to prevent lost data

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -3052,7 +3052,7 @@ function do_computercomputer_migration($migration)
       'bios_manufacturers_id'
     ];
 
-    $a_table['renamefields'] = [];
+    $a_table['renamefields']['last_fusioninventory_update'] = 'last_inventory_update';
 
     $a_table['keys']   = [];
     $a_table['keys'][] = ['field' => 'computers_id', 'name' => '', 'type' => 'INDEX'];


### PR DESCRIPTION
When ```migration``` handle ```glpi_plugin_fusioninventory_inventorycomputercomputers```

Table is renamed to ```glpi_plugin_glpiinventory_inventorycomputercomputers```

But column ```last_fusioninventory_update``` is not renamed to ```last_inventory_update```

```migration``` script create ```last_inventory_update``` (with ```NULL```) and drop ```last_fusioninventory_update``` 
instead of rename it (and keep data).

This PR fix this and fix #372 too

