### PR TITLE
remove deprecated import[rel] (was a hack anywary) to wakeup local agent

### DIFF
--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -70,7 +70,7 @@ if (isset($_POST['prepareinstall'])) {
                 $port = (int)$agent->fields['port'];
             }
             if ($port == 0) {
-                $port = 62354;
+                $port = Agent::DEFAULT_PORT;
             }
             echo Html::scriptBlock("
                 $.get('http://127.0.0.1:{$port}/now');

--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -69,6 +69,9 @@ if (isset($_POST['prepareinstall'])) {
                 $agent->getFromDBByCrit(['itemtype' => 'Computer', 'items_id' => $computers_id]);
                 $port = (int)$agent->fields['port'];
             }
+            if ($port == 0) {
+                $port = 62354;
+            }
             echo Html::scriptBlock("
                 $.get('http://127.0.0.1:{$port}/now');
                 setTimeout(function(){

--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -63,8 +63,14 @@ if (isset($_POST['prepareinstall'])) {
    //If it's a local wakeup, local call to the agent RPC service
     switch ($_POST['wakeup_type']) {
         case 'local':
+            $port = 62354;
+            if ($computers_id) {
+                $agent = new Agent();
+                $agent->getFromDBByCrit(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+                $port = (int)$agent->fields['port'];
+            }
             echo Html::scriptBlock("
-                $.get('http://127.0.0.1:62354/now');
+                $.get('http://127.0.0.1:{$port}/now');
                 setTimeout(function(){
                     window.location='{$_SERVER['HTTP_REFERER']}';
                 }, 500);

--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -63,7 +63,7 @@ if (isset($_POST['prepareinstall'])) {
    //If it's a local wakeup, local call to the agent RPC service
     switch ($_POST['wakeup_type']) {
         case 'local':
-            $port = 62354;
+            $port = Agent::DEFAULT_PORT;
             if ($computers_id) {
                 $agent = new Agent();
                 $agent->getFromDBByCrit(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/front/deploypackage.public.php
+++ b/front/deploypackage.public.php
@@ -63,10 +63,12 @@ if (isset($_POST['prepareinstall'])) {
    //If it's a local wakeup, local call to the agent RPC service
     switch ($_POST['wakeup_type']) {
         case 'local':
-            echo '<link rel="import" href="http://127.0.0.1:62354/now">';
-            echo Html::scriptBlock("setTimeout(function(){
-            window.location='{$_SERVER['HTTP_REFERER']}';
-         }, 500);");
+            echo Html::scriptBlock("
+                $.get('http://127.0.0.1:62354/now');
+                setTimeout(function(){
+                    window.location='{$_SERVER['HTTP_REFERER']}';
+                }, 500);
+            ");
             exit;
          break;
         case 'remote':


### PR DESCRIPTION
CF !29180

Import[rel] is deprecated in modern browsers, but anyway it was a hack.
With this change, the browser will say there is cors issue, but the agent will still get the order.

@g-bougard is currently working on adding cors headers on agent to remove the exception side of GLPI.