### PR TITLE
fix(netinventory): handle XML with <ERROR> node

### DIFF
--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -140,6 +140,9 @@ class PluginGlpiinventoryCommunicationNetworkInventory
             $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '==inventorystarted==';
             $this->addtaskjoblog();
             $response = ['response' => ['RESPONSE' => 'SEND']];
+        } elseif (isset($a_CONTENT->content->error)) {
+            $pfTaskjobstate->fail($a_CONTENT->content->error);
+            $response['response'] = ['RESPONSE' => 'SEND'];
         } elseif (isset($a_CONTENT->content->device->error)) {
             $itemtype = "";
             if ($a_CONTENT->content->device->error->type == "NETWORKING" || $a_CONTENT->content->device->error->type == "STORAGE") {

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -141,7 +141,6 @@ class PluginGlpiinventoryCommunicationNetworkInventory
             $this->addtaskjoblog();
             $response = ['response' => ['RESPONSE' => 'SEND']];
         } elseif (isset($a_CONTENT->content->error)) {
-
             $itemtype = "";
             if ($a_CONTENT->content->error->type == "NETWORKING" || $a_CONTENT->content->error->type == "STORAGE") {
                 $itemtype = "NetworkEquipment";

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -141,7 +141,18 @@ class PluginGlpiinventoryCommunicationNetworkInventory
             $this->addtaskjoblog();
             $response = ['response' => ['RESPONSE' => 'SEND']];
         } elseif (isset($a_CONTENT->content->error)) {
-            $pfTaskjobstate->fail($a_CONTENT->content->error);
+
+            $itemtype = "";
+            if ($a_CONTENT->content->error->type == "NETWORKING" || $a_CONTENT->content->error->type == "STORAGE") {
+                $itemtype = "NetworkEquipment";
+            } elseif ($a_CONTENT->content->error->type == "PRINTER") {
+                $itemtype = "Printer";
+            }
+            $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '[==detail==] ' .
+            $a_CONTENT->content->error->message . ' [[' . $itemtype . '::' .
+            $a_CONTENT->content->error->id . ']]';
+            $this->addtaskjoblog();
+
             $response['response'] = ['RESPONSE' => 'SEND'];
         } elseif (isset($a_CONTENT->content->device->error)) {
             $itemtype = "";


### PR DESCRIPTION
Replace #401 

Try to handle ```<ERROR>``` node from different place

```$a_CONTENT->content->error```

already manage : 

```$a_CONTENT->content->device->error```

need https://github.com/glpi-project/inventory_format/pull/121

