### PR TITLE
fix(migration): add missing glpi display pref migration

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -4742,6 +4742,12 @@ function do_printer_migration($migration)
             "PluginFusinvsnmpPrinterLogReport",
             "PluginGlpiinventoryPrinterLogReport"
         );
+
+        changeDisplayPreference(
+            "PluginFusioninventoryPrinterLogReport",
+            "PluginGlpiinventoryPrinterLogReport"
+        );
+
         changeDisplayPreference("5156", "PluginFusinvsnmpPrinterCartridge");
     }
 


### PR DESCRIPTION
add missing glpi display pref migration

```PluginFusioninventoryPrinterLogReport``` => ```PluginGlpiinventoryPrinterLogReport```

at some point the Fusioninventory plugin move ```PluginFusinvsnmpPrinterLogReport``` to ```PluginFusioninventoryPrinterLogReport```

```plugins/fusioninventory/install/update.php  L4227```

```php
      changeDisplayPreference("PluginFusinvsnmpPrinterLogReport",
                           "PluginFusioninventoryPrinterLogReport");
```

