### PR TITLE
fix(html): add empty col for massiveaction not available for dynmaicroup

### DIFF
--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -789,6 +789,7 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
         foreach ($iterator as $data) {
             $this->getFromDB($data['plugin_glpiinventory_deploygroups_id']);
             echo "<tr>";
+            echo "<td></td>";
             echo "<td>";
             echo "<a href='" . $link . "?id=" . $this->fields['id'] . "'>" . $this->fields['name'] . "</a>";
             echo "</td>";

--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -789,7 +789,9 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
         foreach ($iterator as $data) {
             $this->getFromDB($data['plugin_glpiinventory_deploygroups_id']);
             echo "<tr>";
-            echo "<td></td>";
+            if ($canedit) {
+                echo "<td></td>";
+            }
             echo "<td>";
             echo "<a href='" . $link . "?id=" . $this->fields['id'] . "'>" . $this->fields['name'] . "</a>";
             echo "</td>";


### PR DESCRIPTION
Add empty ```<td></td>``` to massiveaction column

"empty" because computer are addded dynamically and it must not be possible to remove it 

Fix : #410