### PR TITLE
fix(SNMPinventory): get IP in IPRange

### DIFF
--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -583,7 +583,7 @@ class PluginGlpiinventoryNetworkinventory extends PluginGlpiinventoryCommunicati
                 //check all IP to get one that match IPRange
                 foreach ($all_ip as $value) {
                     //if ip is in range use it
-                    if (ip2long($value) <= ip2long($iprange->fields['ip_end']) && ip2long($value) <= ip2long($iprange->fields['ip_start'])) {
+                    if (ip2long($value) <= ip2long($iprange->fields['ip_end']) && ip2long($value) >= ip2long($iprange->fields['ip_start'])) {
                         $ip = $value;
                         break;
                     }

--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -588,6 +588,8 @@ class PluginGlpiinventoryNetworkinventory extends PluginGlpiinventoryCommunicati
                         break;
                     }
                 }
+            } else {
+                $ip = current($all_ip);
             }
         }
 


### PR DESCRIPTION
from ```IPRange``` check the list of ```IPs``` and only use the one (first) that corresponds to the ```IPRange```

fix #415 