### PR TITLE
fix(update): prevent SQL Fatal Error about 'restrict_to_task_entity' field not found from DB

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -8686,7 +8686,7 @@ function migrateTablesFromFusinvDeploy($migration)
         $DB->update(
             PluginGlpiinventoryDeployPackageItem::getTable(),
             [
-             'json' => $json_order
+             'json' => Toolbox::addslashes_deep(json_encode($json_order, JSON_UNESCAPED_SLASHES)),
             ],
             [
              'id' => $order_config['id'],

--- a/install/update.php
+++ b/install/update.php
@@ -8683,11 +8683,15 @@ function migrateTablesFromFusinvDeploy($migration)
          //"deployorders fixer : final order structure for ID ".$order_config['id']."\n" .
        //   json_encode($json_order,JSON_PRETTY_PRINT) ."\n"
        //);
-        $migration->addField('glpi_plugin_glpiinventory_taskjobs', 'restrict_to_task_entity', 'bool', ['value'   => '1']);
-        $migration->migrationOneTable('glpi_plugin_glpiinventory_taskjobs');
-
-        $pfDeployPackageItem = new PluginGlpiinventoryDeployPackageItem();
-        $pfDeployPackageItem->updateOrderJson($order_config['id'], $json_order);
+        $DB->update(
+            PluginGlpiinventoryDeployPackageItem::getTable(),
+            [
+             'json' => $json_order
+            ],
+            [
+             'id' => Toolbox::addslashes_deep($order_config['id'])
+            ]
+        );
     }
 
    /**

--- a/install/update.php
+++ b/install/update.php
@@ -8683,6 +8683,9 @@ function migrateTablesFromFusinvDeploy($migration)
          //"deployorders fixer : final order structure for ID ".$order_config['id']."\n" .
        //   json_encode($json_order,JSON_PRETTY_PRINT) ."\n"
        //);
+        $migration->addField('glpi_plugin_glpiinventory_taskjobs', 'restrict_to_task_entity', 'bool', ['value'   => '1']);
+        $migration->migrationOneTable('glpi_plugin_glpiinventory_taskjobs');
+
         $pfDeployPackageItem = new PluginGlpiinventoryDeployPackageItem();
         $pfDeployPackageItem->updateOrderJson($order_config['id'], $json_order);
     }

--- a/install/update.php
+++ b/install/update.php
@@ -8689,7 +8689,7 @@ function migrateTablesFromFusinvDeploy($migration)
              'json' => $json_order
             ],
             [
-             'id' => Toolbox::addslashes_deep($order_config['id'])
+             'id' => $order_config['id'],
             ]
         );
     }


### PR DESCRIPTION
During installation process the first file executed is ```install/update.php```

```php
function plugin_glpiinventory_install()
{
    ini_set("max_execution_time", "0");

    if (basename($_SERVER['SCRIPT_NAME']) != "cli_install.php") {
        if (!isCommandLine()) {
            Html::header(__('Setup', 'glpiinventory'), $_SERVER['PHP_SELF'], "config", "plugins");
        }
        $migrationname = 'Migration';
    } else {
        $migrationname = 'CliMigration';
    }

    require_once(PLUGIN_GLPI_INVENTORY_DIR . "/install/update.php");
    $version_detected = pluginGlpiinventoryGetCurrentVersion();

    if (
        !defined('FORCE_INSTALL')
        &&
        isset($version_detected)
        && (
         defined('FORCE_UPGRADE')
         || (
            $version_detected != '0'
         )
        )
    ) {
       // note: if version detected = version found can have problem, so need
       //       pass in upgrade to be sure all OK
        pluginGlpiinventoryUpdate($version_detected, $migrationname);
        require_once PLUGIN_GLPI_INVENTORY_DIR . '/install/update.native.php';
        $version_detected = pluginGlpiinventoryGetCurrentVersion();
        pluginGlpiinventoryUpdateNative($version_detected, $migrationname);
    } else {
        require_once(PLUGIN_GLPI_INVENTORY_DIR . "/install/install.php");
        pluginGlpiinventoryInstall(PLUGIN_GLPIINVENTORY_VERSION, $migrationname);
    }
    return true;
}
```

In this file, if  ```deploypackage``` exists, a migration phase  (to fix ```json``` structure) is launched

During this phase, the plugin loads information (using an SQL query) from the ```glpi_plugin_glpiinventory_taskjobs``` table, which does not yet have the new ```restrict_to_task_entity``` field (adding in ```install/update.native.php``` and launch after ```/install/update.php``` ).

The field has not yet been added in these conditions, which causes an SQL error

```shell
[2023-10-06 14:41:39] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Call to a member function fetch_fields() on bool in /home/stanislas/TECLIB/DEV/GLPI/10.0-bugfixes/src/DBmysqlIterator.php at line 856
  Backtrace :
  plugins/glpiinventory/inc/toolbox.class.php:281    DBmysqlIterator->fetchFields()
  plugins/glpiinventory/inc/task.class.php:1925      PluginGlpiinventoryToolbox::fetchAssocByTableIterator()
  ...s/glpiinventory/inc/deploypackage.class.php:109 PluginGlpiinventoryTask::getItemsFromDB()
  src/CommonDBTM.php:1563                            PluginGlpiinventoryDeployPackage->getFromDB()
  ...piinventory/inc/deploypackageitem.class.php:339 CommonDBTM->update()
  plugins/glpiinventory/install/update.php:8830      PluginGlpiinventoryDeployPackageItem->updateOrderJson()
  plugins/glpiinventory/install/update.php:501       migrateTablesFromFusinvDeploy()
  plugins/glpiinventory/hook.php:409                 pluginGlpiinventoryUpdate()
  src/Plugin.php:915                                 plugin_glpiinventory_install()
  src/Console/Plugin/InstallCommand.php:145          Plugin->install()
  vendor/symfony/console/Command/Command.php:298     Glpi\Console\Plugin\InstallCommand->execute()
  vendor/symfony/console/Application.php:1040        Symfony\Component\Console\Command\Command->run()
  src/Console/Application.php:272                    Symfony\Component\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:301         Glpi\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:171         Symfony\Component\Console\Application->doRun()
  bin/console:122                                    Symfo
```

This PR fix this

Fix internal ref : !29681

