### PR TITLE
Remove call to long time removed method

### DIFF
--- a/inc/deploytaskjob.class.php
+++ b/inc/deploytaskjob.class.php
@@ -289,10 +289,6 @@ class PluginGlpiinventoryDeployTaskjob extends CommonDBTM
                         }
                         $res = json_encode($res);
                         break;
-
-                    case 'PluginGlpiinventoryDeployGroup':
-                        $res = PluginGlpiinventoryDeployGroup::getAllDatas('action_selections');
-                        break;
                 }
                 break;
 


### PR DESCRIPTION
Curent code calls `PluginGlpiinventoryDeployGroup::getAllDatas` method; which has been removed in 2014 (see https://github.com/glpi-project/glpi-inventory-plugin/commit/59706482ee8dbc6b717fe39b07aace6a47680a9f).

This seems a dead case.