### PR TITLE
fix(menu): page not found

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -40,7 +40,7 @@ Html::header(
     $_SERVER["PHP_SELF"],
     "admin",
     "pluginglpiinventorymenu",
-    "config"
+    "menu"
 );
 
 


### PR DESCRIPTION
From the general setup, the search button is a link to the `.../glpiinventory/front/config.php` page, which doesn't exist.

This link doesn't seem relevant on this page, so I think we can just remove it.

![image](https://github.com/glpi-project/glpi-inventory-plugin/assets/8530352/60763203-04f0-4752-bf21-cb5098c63481)

Ref: !30285