### PR TITLE
Fix static group criteria

### DIFF
--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -695,7 +695,7 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
         }
 
         $computers_params["reset"] = true;
-        return Search::manageParams('Computer', $computers_params, true, false);
+        return Search::manageParams('Computer', $computers_params, false, false);
     }
 
 

--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -659,6 +659,7 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
     {
         global $DB;
 
+        $is_dynamic = $group->isDynamicGroup();
         $computers_params = [];
 
        //Check criteria from DB
@@ -695,7 +696,7 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
         }
 
         $computers_params["reset"] = true;
-        return Search::manageParams('Computer', $computers_params, false, false);
+        return Search::manageParams('Computer', $computers_params, $is_dynamic, false);
     }
 
 

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -170,7 +170,6 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $search_params['massiveactionparams']['extraparams']['specific_actions']['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'] = __('Add to static group', 'glpiinventory');
         $search_params['massiveactionparams']['extraparams']['massive_action_fields'] = ['action', 'id'];
 
-        //$backup_computer_search = $_SESSION['glpisearch']['Computer'];
         $data = Search::prepareDatasForSearch('Computer', $search_params);
         $data['itemtype'] = 'Computer';
         Search::constructSQL($data);

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -180,7 +180,6 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $_SESSION['glpilist_limit'] = 200;
         Search::displayData($data);
         $_SESSION['glpilist_limit'] = $limit_backup;
-        //$_SESSION['glpisearch']['Computer'] = $backup_computer_search;
 
         //remove trashbin switch
         echo Html::scriptBlock("

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -170,6 +170,7 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $search_params['massiveactionparams']['extraparams']['specific_actions']['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'] = __('Add to static group', 'glpiinventory');
         $search_params['massiveactionparams']['extraparams']['massive_action_fields'] = ['action', 'id'];
 
+        $backup_computer_search = $_SESSION['glpisearch']['Computer'];
         $data = Search::prepareDatasForSearch('Computer', $search_params);
         $data['itemtype'] = 'Computer';
         Search::constructSQL($data);
@@ -180,6 +181,7 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $_SESSION['glpilist_limit'] = 200;
         Search::displayData($data);
         $_SESSION['glpilist_limit'] = $limit_backup;
+        $_SESSION['glpisearch']['Computer'] = $backup_computer_search;
 
         //remove trashbin switch
         echo Html::scriptBlock("

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -171,11 +171,9 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $search_params['massiveactionparams']['extraparams']['massive_action_fields'] = ['action', 'id'];
 
         $data = Search::prepareDatasForSearch('Computer', $search_params);
-        $data['itemtype'] = 'Computer';
         Search::constructSQL($data);
         Search::constructData($data);
         $data['search']['target'] = PluginGlpiinventoryDeployGroup::getSearchEngineTargetURL($item->getID(), false);
-        $data['itemtype'] = 'Computer';
         $limit_backup = $_SESSION['glpilist_limit'];
         $_SESSION['glpilist_limit'] = 200;
         Search::displayData($data);

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -170,7 +170,7 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $search_params['massiveactionparams']['extraparams']['specific_actions']['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'] = __('Add to static group', 'glpiinventory');
         $search_params['massiveactionparams']['extraparams']['massive_action_fields'] = ['action', 'id'];
 
-        $backup_computer_search = $_SESSION['glpisearch']['Computer'];
+        //$backup_computer_search = $_SESSION['glpisearch']['Computer'];
         $data = Search::prepareDatasForSearch('Computer', $search_params);
         $data['itemtype'] = 'Computer';
         Search::constructSQL($data);
@@ -181,7 +181,7 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $_SESSION['glpilist_limit'] = 200;
         Search::displayData($data);
         $_SESSION['glpilist_limit'] = $limit_backup;
-        $_SESSION['glpisearch']['Computer'] = $backup_computer_search;
+        //$_SESSION['glpisearch']['Computer'] = $backup_computer_search;
 
         //remove trashbin switch
         echo Html::scriptBlock("

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -170,12 +170,12 @@ class PluginGlpiinventoryDeployGroup_Staticdata extends CommonDBRelation
         $search_params['massiveactionparams']['extraparams']['specific_actions']['PluginGlpiinventoryComputer' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'] = __('Add to static group', 'glpiinventory');
         $search_params['massiveactionparams']['extraparams']['massive_action_fields'] = ['action', 'id'];
 
-        $data = Search::prepareDatasForSearch('PluginGlpiinventoryComputer', $search_params);
+        $data = Search::prepareDatasForSearch('Computer', $search_params);
         $data['itemtype'] = 'Computer';
         Search::constructSQL($data);
         Search::constructData($data);
         $data['search']['target'] = PluginGlpiinventoryDeployGroup::getSearchEngineTargetURL($item->getID(), false);
-        $data['itemtype'] = 'PluginGlpiinventoryComputer';
+        $data['itemtype'] = 'Computer';
         $limit_backup = $_SESSION['glpilist_limit'];
         $_SESSION['glpilist_limit'] = 200;
         Search::displayData($data);


### PR DESCRIPTION
Try to fix #430 

Search from static group is a litlle bit different than "Computer" search (Glpiinventory plugin use it's own derived class ```PluginGlpiinventoryComputer```)

```PluginGlpiinventoryComputer``` is mainly used to override standard massiveaction and get only one "Add to static group or "Remove from static group".

First commit  allow saerch engine to correctly compute SQL query based on ```Computer```

Second commit backup and restore ```$_SESSION['glpisearch']['Computer']``` to prevent the search carried out in the static group from overwriting the last search carried out on the Computer.