### PR TITLE
fix(migration): PluginGlpiinventoryDeployPackageItem is an abstract class ...

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -8684,7 +8684,7 @@ function migrateTablesFromFusinvDeploy($migration)
        //   json_encode($json_order,JSON_PRETTY_PRINT) ."\n"
        //);
         $DB->update(
-            PluginGlpiinventoryDeployPackageItem::getTable(),
+            PluginGlpiinventoryDeployPackage::getTable(),
             [
              'json' => Toolbox::addslashes_deep(json_encode($json_order, JSON_UNESCAPED_SLASHES)),
             ],


### PR DESCRIPTION
Fix error introduced by this
https://github.com/glpi-project/glpi-inventory-plugin/pull/419

```PluginGlpiinventoryDeployPackageItem``` is an abstract class and therefore has no database table

Original code 

```php
$pfDeployPackageItem = new PluginGlpiinventoryDeployPackageItem();
$pfDeployPackageItem->updateOrderJson($order_config['id'], $json_order);
``` 

use ```PluginGlpiinventoryDeployPackage``` to migration ```json``` column

```php
    public function updateOrderJson($packages_id, $data)
    {
        $pfDeployPackage   = new PluginGlpiinventoryDeployPackage();   // HERE
        $options           = JSON_UNESCAPED_SLASHES;
        $json              = json_encode($data, $options);
        $json_error_consts = [
         JSON_ERROR_NONE           => "JSON_ERROR_NONE",
         JSON_ERROR_DEPTH          => "JSON_ERROR_DEPTH",
         JSON_ERROR_STATE_MISMATCH => "JSON_ERROR_STATE_MISMATCH",
         JSON_ERROR_CTRL_CHAR      => "JSON_ERROR_CTRL_CHAR",
         JSON_ERROR_SYNTAX         => "JSON_ERROR_SYNTAX",
         JSON_ERROR_UTF8           => "JSON_ERROR_UTF8"
        ];
        $error_json         = json_last_error();
        $error_json_message = json_last_error_msg();
        $error              = 0;
        if ($error_json != JSON_ERROR_NONE) {
            $error_msg = $json_error_consts[$error_json];
            Session::addMessageAfterRedirect(
                __("The modified JSON contained a syntax error :", "glpiinventory") . "<br/>" .
                $error_msg . "<br/>" . $error_json_message,
                false,
                ERROR,
                false
            );
            $error = 1;
        } else {
            $error = $pfDeployPackage->update(['id'   => $packages_id,
                                            'json' => Toolbox::addslashes_deep($json)]);
        }
        return $error;
    }
```


