### PR TITLE
NetInventory PROLOG answer optimization

### DIFF
--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -634,7 +634,8 @@ class PluginGlpiinventoryNetworkinventory extends PluginGlpiinventoryCommunicati
                     "Merged with " . $changestate
                 );
             }
-            $snmpauthlist = $credentials->find();
+            // Only keep required snmp credentials
+            $snmpauthlist = $credentials->find(['id' => $a_extended['snmpcredentials_id']]);
             foreach ($snmpauthlist as $snmpauth) {
                 $auth_node = $pfToolbox->addAuth($snmpauth['id']);
                 if (count($auth_node)) {

--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -581,6 +581,8 @@ class PluginGlpiinventoryNetworkinventory extends PluginGlpiinventoryCommunicati
                 1,
                 "Device have no ip"
             );
+            // Return an empty list to avoid adding an option with no data in the joblist
+            return [];
         } else {
            // Use general config when threads number is set to 0 on the agent
             $param_attrs['THREADS_QUERY'] = $agent->fields["threads_networkinventory"] == 0 ?

--- a/tests/Integration/Tasks/NetworkInventoryTest.php
+++ b/tests/Integration/Tasks/NetworkInventoryTest.php
@@ -439,12 +439,6 @@ class NetworkInventoryTest extends TestCase
                ]
             ], [
                'AUTHENTICATION' => [
-                  'ID'        => 1,
-                  'VERSION'   => 1,
-                  'COMMUNITY' => 'public'
-               ]
-            ], [
-               'AUTHENTICATION' => [
                   'ID'        => 2,
                   'VERSION'   => '2c',
                   'COMMUNITY' => 'public'


### PR DESCRIPTION
This little PR updates XML response to PROLOG requests:
1. when a device is found without ip (rare case, but I see it in a client case), we had an OPTION node without data: `<OPTION><NAME>SNMPQUERY</NAME><PARAM/><DEVICE/></OPTION>`
   This node involves the agent reports an error on invalid data but it will still handle all netinventory requests based on valid datas. So this is not a big deal anyway.
2. an iprange can be setup with a lot of credentials and they are always all added to each netinventory device request. This can lead to a heavy PROLOG response when a lot of iprange with many discovered devices are returned in the PROLOG response. Limiting to only keep the required credentials is an optimization as anyway only one snmp credentials will be really used and we still know which one. Working on !29659, I saw XML response to PROLOG of around 400Ko. With this little optimization it would have been reduced to 250Ko.