### PR TITLE
1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+
+## [1.3.5] - 2024-02-26
+
 ### Changes
 
 - ```Upload from server``` option is no longer available in a ```CLOUD``` context
 
 ### Fixed
+
+- Prevents the task from being cancelled if the agent wakes up too early
 
 ### Added
 

--- a/glpiinventory.xml
+++ b/glpiinventory.xml
@@ -92,6 +92,11 @@
    </authors>
    <versions>
       <version>
+         <num>1.3.5</num>
+         <compatibility>~10.0.10</compatibility>
+         <download_url>https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.3.5/glpi-glpiinventory-1.3.5.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.3.4</num>
          <compatibility>~10.0.10</compatibility>
          <download_url>https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.3.4/glpi-glpiinventory-1.3.4.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -33,7 +33,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define("PLUGIN_GLPIINVENTORY_VERSION", "1.3.4");
+define("PLUGIN_GLPIINVENTORY_VERSION", "1.3.5");
 // Minimal GLPI version, inclusive
 define('PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION', '10.0.11');
 // Maximum GLPI version, exclusive


### PR DESCRIPTION
## [1.3.5] - 2024-02-26

### Changes

- ```Upload from server``` option is no longer available in a ```CLOUD``` context

### Fixed

- Prevents the task from being cancelled if the agent wakes up too early

### Added