### PR TITLE
fix: dynamic groups missing on computer

### DIFF
--- a/front/deploygroup.form.php
+++ b/front/deploygroup.form.php
@@ -62,6 +62,7 @@ if (isset($_GET['save'])) {
         $values['fields_array'] = serialize($criteria);
         $group_item->update($values);
     }
+    PluginGlpiinventoryDeployGroup::getTargetsForGroup($_GET['id']);
 
     Html::redirect(Toolbox::getItemTypeFormURL("PluginGlpiinventoryDeployGroup") . "?id=" . $_GET['id']);
 } elseif (isset($_FILES['importcsvfile'])) {
@@ -111,5 +112,6 @@ if (isset($_GET['save'])) {
         $values['preview'] = $_GET['preview'];
     }
     $group->display($values);
+    PluginGlpiinventoryDeployGroup::getTargetsForGroup($_GET['id']);
     Html::footer();
 }

--- a/front/deploygroup.form.php
+++ b/front/deploygroup.form.php
@@ -62,7 +62,7 @@ if (isset($_GET['save'])) {
         $values['fields_array'] = serialize($criteria);
         $group_item->update($values);
     }
-    PluginGlpiinventoryDeployGroup::getTargetsForGroup($_GET['id']);
+    PluginGlpiinventoryDeployGroup::getTargetsForGroup((int) $_GET['id']);
 
     Html::redirect(Toolbox::getItemTypeFormURL("PluginGlpiinventoryDeployGroup") . "?id=" . $_GET['id']);
 } elseif (isset($_FILES['importcsvfile'])) {
@@ -112,6 +112,6 @@ if (isset($_GET['save'])) {
         $values['preview'] = $_GET['preview'];
     }
     $group->display($values);
-    PluginGlpiinventoryDeployGroup::getTargetsForGroup($id);
+    PluginGlpiinventoryDeployGroup::getTargetsForGroup((int) $id);
     Html::footer();
 }

--- a/front/deploygroup.form.php
+++ b/front/deploygroup.form.php
@@ -112,6 +112,6 @@ if (isset($_GET['save'])) {
         $values['preview'] = $_GET['preview'];
     }
     $group->display($values);
-    PluginGlpiinventoryDeployGroup::getTargetsForGroup($_GET['id']);
+    PluginGlpiinventoryDeployGroup::getTargetsForGroup($id);
     Html::footer();
 }


### PR DESCRIPTION
Compute more often `computers_id_cache`, which displays dynamic groups in a computer's "Tasks / Groups" tab

ref !31924