### PR TITLE
Display all computers details for dynamics group

### DIFF
--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -163,7 +163,7 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
                     $params['metacriteria'] = [];
                 }
                 $params['target'] = PluginGlpiinventoryDeployGroup::getSearchEngineTargetURL($_GET['id'], true);
-                self::showList('Computer', $params, ['1', '2']);
+                self::showList('Computer', $params, []);
                 return true;
         }
         return false;
@@ -216,15 +216,6 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
         Search::constructSQL($data);
         Search::constructData($data);
 
-        // Remove some fields from the displayed columns
-        if (Session::isMultiEntitiesMode()) {
-           // Remove entity and computer Id
-            unset($data['data']['cols'][1]);
-            unset($data['data']['cols'][2]);
-        } else {
-            // Remove computer Id
-            unset($data['data']['cols'][1]);
-        }
         Search::displayData($data);
     }
 

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -170,7 +170,6 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
     }
 
 
-
    /**
     * Display criteria form + list of computers
     *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33174

On the basic group page, the only information displayed is the group name and status, but it's true that it was nicer and more practical to display all the information.

**Before**
![image](https://github.com/glpi-project/glpi-inventory-plugin/assets/107540223/7b1c0ad9-f834-4386-ab4b-f23288cc02b4)

**After**
![image](https://github.com/glpi-project/glpi-inventory-plugin/assets/107540223/9d2f2c28-3e70-4db1-bf2f-ec00552b6abf)
