### PR TITLE
Fix management of the “include old jobs” parameter

### DIFF
--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -623,6 +623,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
             if (count($task['jobs']) == 0) {
                 echo NL;
             } else {
+                $log_cpt = 0;
                 foreach ($task['jobs'] as $job_id => $job) {
                     echo $job['name'] . SEP;
                     echo $job['method'] . SEP;
@@ -641,7 +642,6 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                                     $computer->getFromDB($agent_obj->fields['items_id']);
                                     echo $computer->getname() . SEP;
 
-                                    $log_cpt = 0;
                                     if (count($agent) == 0) {
                                         echo NL;
                                     } else {
@@ -649,11 +649,6 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                                             echo $exec['last_log_date'] . SEP;
                                             echo $exec['state'] . SEP;
                                             echo $exec['last_log'] . NL;
-                                            $log_cpt++;
-
-                                            if ($includeoldjobs != -1 and $log_cpt >= $includeoldjobs) {
-                                                break;
-                                            }
 
                                             if (!$last($agent, $exec_id)) {
                                                 echo SEP . SEP . SEP . SEP . SEP . SEP;
@@ -675,6 +670,12 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
 
                     if (!$last($task['jobs'], $job_id)) {
                         echo SEP;
+                    }
+
+                    $log_cpt++;
+
+                    if ($includeoldjobs != -1 and $log_cpt >= $includeoldjobs) {
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
The `inculde old jobs` parameter only modified the number of rows generated in the csv, not the number of jobs included.
Here's a screenshot of an export with `include old jobs` set to 2: 

![image](https://github.com/glpi-project/glpi-inventory-plugin/assets/102067890/f7c9afae-c268-4d37-a802-6f773cfc0943)

![image](https://github.com/glpi-project/glpi-inventory-plugin/assets/102067890/64986688-c00e-4ddf-8ce8-a9e24d78fe9c)

By increasing this value, additional lines are added : 

![image](https://github.com/glpi-project/glpi-inventory-plugin/assets/102067890/4debc8cc-f788-4aa1-9ce7-b3545bff4f6a)

The solution was to move the counter that stops the addition of rows in the CSV, so that it applies to jobs and not rows.