### PR TITLE
Fix(Core): remove calls to a missing GLPI pics

### DIFF
--- a/inc/deployaction.class.php
+++ b/inc/deployaction.class.php
@@ -246,7 +246,6 @@ class PluginGlpiinventoryDeployAction extends PluginGlpiinventoryDeployPackageIt
         }
         echo "</table>";
         if ($canedit) {
-            echo "&nbsp;&nbsp;<img src='" . $CFG_GLPI["root_doc"] . "/pics/arrow-left.png' alt=''>";
             echo "<input type='submit' name='delete' value=\"" .
             __('Delete', 'glpiinventory') . "\" class='submit'>";
         }

--- a/inc/deploycheck.class.php
+++ b/inc/deploycheck.class.php
@@ -285,7 +285,6 @@ class PluginGlpiinventoryDeployCheck extends PluginGlpiinventoryDeployPackageIte
         }
         echo "</table>";
         if ($canedit) {
-            echo "&nbsp;&nbsp;<img src='" . $CFG_GLPI["root_doc"] . "/pics/arrow-left.png' alt='' />";
             echo "<input type='submit' name='delete' value=\"" .
             __('Delete', 'glpiinventory') . "\" class='submit' />";
         }

--- a/inc/deployuserinteraction.class.php
+++ b/inc/deployuserinteraction.class.php
@@ -295,7 +295,6 @@ class PluginGlpiinventoryDeployUserinteraction extends PluginGlpiinventoryDeploy
         }
         echo "</table>";
         if ($canedit) {
-            echo "&nbsp;&nbsp;<img src='" . $CFG_GLPI["root_doc"] . "/pics/arrow-left.png' alt='' />";
             echo "<input type='submit' name='delete' value=\"" .
             __('Delete', 'glpiinventory') . "\" class='submit' />";
         }

--- a/inc/taskjob.class.php
+++ b/inc/taskjob.class.php
@@ -1182,7 +1182,6 @@ function new_subtype(id) {
         echo "</th><th colspan='3' class='mark'></th></tr>";
         echo "</table>";
         echo "</div>";
-        echo "&nbsp;&nbsp;<img src='" . $CFG_GLPI["root_doc"] . "/pics/arrow-left.png' alt=''>";
         echo "<input type='submit' name='delete' value=\"" .
          __('Delete', 'glpiinventory') . "\" class='submit'>";
 


### PR DESCRIPTION
Fix : 

![image](https://github.com/glpi-project/glpi-inventory-plugin/assets/7335054/32fbd05a-1429-477b-a4d9-87f1df973574)

```arrow-left.png``` from GLPI pics folder no longer exist.