### PR TITLE
Fix translation of strings

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -117,7 +117,7 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
         ],
         'task'         => [
             'itemtype' => PluginGlpiinventoryTask::getType(),
-            'label' => sprintf(__("Number of %s"), __('Tasks')),
+            'label' => sprintf(__("Number of %s"), __('Tasks', 'glpiinventory')),
         ],
         'unmanaged'         => [
             'itemtype' => Unmanaged::getType(),

--- a/hook.php
+++ b/hook.php
@@ -125,7 +125,7 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
         ],
         'computer'         => [
             'itemtype' => Computer::getType(),
-            'label' =>  sprintf(__("%s inventoried"), Computer::getTypeName(2)),
+            'label' =>  sprintf(__("%s inventoried", "glpiinventory"), Computer::getTypeName(2)),
             'apply_filters' =>  [
                 'link'          => 'AND',
                 'field'         => 42,
@@ -135,7 +135,7 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
             ],
         'printer'         => [
             'itemtype' => Printer::getType(),
-            'label' =>  sprintf(__("%s inventoried"), Printer::getTypeName(2)),
+            'label' =>  sprintf(__("%s inventoried", "glpiinventory"), Printer::getTypeName(2)),
             'apply_filters' =>  [
                 'link'          => 'AND',
                 'field'         => 72,
@@ -145,7 +145,7 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
             ],
         'networkequipement'         => [
             'itemtype' => NetworkEquipment::getType(),
-            'label' =>  sprintf(__("%s inventoried"), NetworkEquipment::getTypeName(2)),
+            'label' =>  sprintf(__("%s inventoried", "glpiinventory"), NetworkEquipment::getTypeName(2)),
             'apply_filters' =>  [
                 'link'          => 'AND',
                 'field'         => 72,
@@ -155,7 +155,7 @@ function plugin_glpiinventory_hook_dashboard_cards($cards)
             ],
         'phone'         => [
             'itemtype' => Phone::getType(),
-            'label' =>  sprintf(__("%s inventoried"), Phone::getTypeName(2)),
+            'label' =>  sprintf(__("%s inventoried", "glpiinventory"), Phone::getTypeName(2)),
             'apply_filters' =>  [
                 'link'          => 'AND',
                 'field'         => 72,

--- a/inc/timeslotentry.class.php
+++ b/inc/timeslotentry.class.php
@@ -216,7 +216,7 @@ class PluginGlpiinventoryTimeslotEntry extends CommonDBTM
             echo "</td>";
             echo "<td colspan='2'>";
             if ($canedit) {
-                echo "<input type='submit' class='submit' name='purge-" . $dbentry['id'] . "' value='".__('Delete')."' />";
+                echo "<input type='submit' class='submit' name='purge-" . $dbentry['id'] . "' value='" . __('Delete') . "' />";
             }
             echo "</td>";
             echo "</tr>";

--- a/inc/timeslotentry.class.php
+++ b/inc/timeslotentry.class.php
@@ -216,7 +216,7 @@ class PluginGlpiinventoryTimeslotEntry extends CommonDBTM
             echo "</td>";
             echo "<td colspan='2'>";
             if ($canedit) {
-                echo "<input type='submit' class='submit' name='purge-" . $dbentry['id'] . "' value='delete' />";
+                echo "<input type='submit' class='submit' name='purge-" . $dbentry['id'] . "' value='".__('Delete')."' />";
             }
             echo "</td>";
             echo "</tr>";

--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -712,7 +712,7 @@ taskjobs.update_logs = function (data) {
          var targets_cpt = 0;
 
          if(job_v.targets.length === 0) {
-            $(targets_selector).html('The preparation of the task did not return any targets');
+            $(targets_selector).html(__('The preparation of the task did not return any targets', 'glpiinventory'));
          }
 
          $.each( job_v.targets, function( target_i, target_v) {


### PR DESCRIPTION
1. It isn't being translated on PT-BR language.

This fix also requires add the missing "``%s inventoried``" string to the ``.po`` files. E.g. to PT-BR:

```
#: inc/collect_registry_content.class.php:128
#: inc/collect_registry_content.class.php:138
#: inc/collect_registry_content.class.php:148
#: inc/collect_registry_content.class.php:158
msgid "%s inventoried"
msgstr "%s inventariados(as)"
```

2. I also noticed that when creating the Dashboard, the Dashboard title isn't translatable:

https://github.com/glpi-project/glpi-inventory-plugin/blob/main/install/update.php#L1106

But native GLPI dashboard are:

![image](https://github.com/glpi-project/glpi-inventory-plugin/assets/2974895/e6e4a79d-de95-43ad-9dfd-5db3d12d626b)

I couldn't figure it out how to translate it.

3. I believe the word "Time slot" should also be available on plural form.
4. I also noticed that when changing the GLPI UI language to another one (e.g. Portuguese to English), the GLPI Inventory plugin still shows the menus on Portuguese. I'm not sure, but I believe it maybe related to menu.class.php file and a similar issue as the item number 2 of this list. It seems to always use the language that the user was using when installed the plug-in.
5. I found a non-translated English string on ``taskjobs.js`` file that needs to be added to the translation files. E.g. for PT-BR:

```
#: js/taskjobs.js:715
msgid "The preparation of the task did not return any targets"
msgstr "A preparação da tarefa não retornou nenhum alvo"
```