### PR TITLE
Fix NetDiscovery state number display

### DIFF
--- a/inc/statediscovery.class.php
+++ b/inc/statediscovery.class.php
@@ -165,7 +165,7 @@ class PluginGlpiinventoryStateDiscovery extends CommonDBTM
             'ORDER' => 'uniqid DESC'
         ]);
         $result = $iterator->next();
-        $number = $result['cpt'];
+        $number = count($iterator);
 
         // Display the pager
         Html::printPager($start, $number, Plugin::getWebDir('glpiinventory') . "/front/statediscovery.php", '');

--- a/inc/statediscovery.class.php
+++ b/inc/statediscovery.class.php
@@ -164,7 +164,6 @@ class PluginGlpiinventoryStateDiscovery extends CommonDBTM
             'GROUP' => 'uniqid',
             'ORDER' => 'uniqid DESC'
         ]);
-        $result = $iterator->next();
         $number = count($iterator);
 
         // Display the pager


### PR DESCRIPTION
Pagination works on NetInventory state page, but not on NetDiscovery one. This fix it.
Affected URI: https://glpi.example.com/plugins/glpiinventory/front/statediscovery.php