### PR TITLE
Show "entities" tab by default

### DIFF
--- a/install/mysql/plugin_glpiinventory-empty.sql
+++ b/install/mysql/plugin_glpiinventory-empty.sql
@@ -627,4 +627,6 @@ INSERT INTO `glpi_displaypreferences` (`id`, `itemtype`, `num`, `rank`, `users_i
           (NULL,'PluginGlpiinventoryStateDiscovery', '9', '7', '0'),
           (NULL,'PluginGlpiinventoryStateDiscovery', '10', '8', '0'),
           (NULL,'PluginGlpiinventoryStateDiscovery', '11', '9', '0'),
-          (NULL,'PluginGlpiinventoryStateDiscovery', '12', '10', '0');
+          (NULL,'PluginGlpiinventoryStateDiscovery', '12', '10', '0'),
+   
+          (NULL,'PluginGlpiinventoryCredentialIp', '2', '1', '0');

--- a/install/mysql/plugin_glpiinventory-empty.sql
+++ b/install/mysql/plugin_glpiinventory-empty.sql
@@ -628,5 +628,7 @@ INSERT INTO `glpi_displaypreferences` (`id`, `itemtype`, `num`, `rank`, `users_i
           (NULL,'PluginGlpiinventoryStateDiscovery', '10', '8', '0'),
           (NULL,'PluginGlpiinventoryStateDiscovery', '11', '9', '0'),
           (NULL,'PluginGlpiinventoryStateDiscovery', '12', '10', '0'),
-   
-          (NULL,'PluginGlpiinventoryCredentialIp', '2', '1', '0');
+
+          (NULL,'PluginGlpiinventoryCredentialIp', '2', '1', '0'),
+
+          (NULL,'PluginGlpiinventoryCredential', '2', '1', '0');


### PR DESCRIPTION
Show "entities" tab by default on:

- Remote devices to inventory (VMware)
- Authentication for remote devices (VMware)