### PR TITLE
Fix(Core): Optimize dynamic group display

### DIFF
--- a/front/deploygroup.form.php
+++ b/front/deploygroup.form.php
@@ -62,7 +62,6 @@ if (isset($_GET['save'])) {
         $values['fields_array'] = serialize($criteria);
         $group_item->update($values);
     }
-    PluginGlpiinventoryDeployGroup::getTargetsForGroup((int) $_GET['id']);
 
     Html::redirect(Toolbox::getItemTypeFormURL("PluginGlpiinventoryDeployGroup") . "?id=" . $_GET['id']);
 } elseif (isset($_FILES['importcsvfile'])) {
@@ -112,6 +111,5 @@ if (isset($_GET['save'])) {
         $values['preview'] = $_GET['preview'];
     }
     $group->display($values);
-    PluginGlpiinventoryDeployGroup::getTargetsForGroup((int) $id);
     Html::footer();
 }

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -266,9 +266,6 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
                 ['2']
             );
 
-            $results = Search::prepareDatasForSearch('Computer', $search_params, ['2']);
-            Search::constructSQL($results);
-            Search::constructData($results);
 
             foreach ($results['data']['rows'] as $id => $row) {
                  $ids[$row['id']] = $row['id'];


### PR DESCRIPTION
When we display or update a dynamic group

The plugin tries to calculate all the computers (linked to the search) to keep the data in the database (like a cache).

It doesn't need to, because displaying the dynamic group also shows the computers involved

and `getTargetsForGroup`, executes the search twice ...

(so three times in total when displaying a group)