### PR TITLE
1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.3.6] - 2024-09-06
+## [1.4.0] - 2024-09-06
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.6] - 2024-09-06
+
+### Fixed
+
+- The columns could not be added in the computer search view (collect).
+- Fix `invalid item` for obsolete agents.
+- Fix upload directory set in configuration.
+- Fix `cancel` count from job executions.
+- Fix the management of the `include old jobs` parameter.
+- Use Device IP in IP range set on task for Device NetInventory
+- Fix pagination for `NetInventory` state page
+
+### Feat
+
+- Display all computers details for dynamics group
+- Count agent handle by `Taskscheduler`
+
 ### Changes
 
+- Encrypt credentials
 - Displays ```Tasks / Groups``` tab only on computers linked to an agent
 
 

--- a/glpiinventory.xml
+++ b/glpiinventory.xml
@@ -92,9 +92,9 @@
    </authors>
    <versions>
       <version>
-         <num>1.3.6</num>
+         <num>1.4.0</num>
          <compatibility>~10.0.11</compatibility>
-         <download_url>https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.3.6/glpi-glpiinventory-1.3.6.tar.bz2</download_url>
+         <download_url>https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.4.0/glpi-glpiinventory-1.4.0.tar.bz2</download_url>
       </version>
       <version>
          <num>1.3.5</num>

--- a/glpiinventory.xml
+++ b/glpiinventory.xml
@@ -92,6 +92,11 @@
    </authors>
    <versions>
       <version>
+         <num>1.3.6</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.3.6/glpi-glpiinventory-1.3.6.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.3.5</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.3.5/glpi-glpiinventory-1.3.5.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -33,7 +33,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define("PLUGIN_GLPIINVENTORY_VERSION", "1.3.5");
+define("PLUGIN_GLPIINVENTORY_VERSION", "1.3.6");
 // Minimal GLPI version, inclusive
 define('PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION', '10.0.11');
 // Maximum GLPI version, exclusive

--- a/setup.php
+++ b/setup.php
@@ -33,7 +33,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define("PLUGIN_GLPIINVENTORY_VERSION", "1.3.6");
+define("PLUGIN_GLPIINVENTORY_VERSION", "1.4.0");
 // Minimal GLPI version, inclusive
 define('PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION', '10.0.11');
 // Maximum GLPI version, exclusive


### PR DESCRIPTION
## [1.3.6] - 2024-09-06

### Fixed

- The columns could not be added in the computer search view (collect).
- Fix `invalid item` for obsolete agents.
- Fix upload directory set in configuration.
- Fix `cancel` count from job executions.
- Fix the management of the `include old jobs` parameter.
- Use Device IP in IP range set on task for Device NetInventory
- Fix pagination for `NetInventory` state page

### Feat

- Display all computers details for dynamics group
- Count agent handle by `Taskscheduler`

### Changes

- Encrypt credentials
- Displays ```Tasks / Groups``` tab only on computers linked to an agent