### PR TITLE
Feat(GroupDynamic): Isolate search criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Isolate dynamic group criteria to prevent their global reapplication in GLPI.
+
 ## [1.4.0] - 2024-09-06
 
 ### Fixed

--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -661,6 +661,15 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
     {
         global $DB;
 
+        // It's necessary to do a backup of $_SESSION['glpisearch']['Computer']
+        // to isolate the search performed in the dynamic group,
+        // otherwise the search will be reused by GLPI in the computer list (cf.$_SESSION['glpisearch']['Computer'])
+        $backup_criteria = [];
+        if (isset($_SESSION['glpisearch']['Computer'])) {
+            $backup_criteria = $_SESSION['glpisearch']['Computer'];
+        }
+
+
         $is_dynamic = $group->isDynamicGroup();
         $computers_params = [];
 
@@ -698,7 +707,12 @@ class PluginGlpiinventoryDeployGroup extends CommonDBTM
         }
 
         $computers_params["reset"] = true;
-        return Search::manageParams('Computer', $computers_params, $is_dynamic, false);
+        $managed_criteria =  Search::manageParams('Computer', $computers_params, $is_dynamic, false);
+
+        //restore session data
+        $_SESSION['glpisearch']['Computer'] = $backup_criteria;
+
+        return $managed_criteria;
     }
 
 

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -140,13 +140,24 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
     */
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
+        // It's necessary to do a backup of $_SESSION['glpisearch']['Computer']
+        // to isolate the search performed in the dynamic group,
+        // otherwise the search will be reused by GLPI in the computer list (cf.$_SESSION['glpisearch']['Computer'])
+        $backup_criteria = [];
+        if (isset($_SESSION['glpisearch']['Computer'])) {
+            $backup_criteria = $_SESSION['glpisearch']['Computer'];
+        }
+
+
         switch ($tabnum) {
             case 1:
                 self::showCriteriaAndSearch($item);
+                //restore session data
+                $_SESSION['glpisearch']['Computer'] = $backup_criteria;
                 return true;
 
             case 2:
-               // Save pagination parameters
+
                 $pagination_params = [];
                 foreach (['sort', 'order', 'start'] as $field) {
                     if (isset($_SESSION['glpisearch']['Computer'][$field])) {
@@ -164,6 +175,10 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
                 }
                 $params['target'] = PluginGlpiinventoryDeployGroup::getSearchEngineTargetURL($_GET['id'], true);
                 self::showList('Computer', $params, []);
+
+                //restore session data
+                $_SESSION['glpisearch']['Computer'] = $backup_criteria;
+
                 return true;
         }
         return false;
@@ -199,6 +214,7 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
         PluginGlpiinventoryDeployGroup::showCriteria($item, $search_params);
         echo '</div>';
         echo '</div>';
+
     }
 
 

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -148,7 +148,6 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
             $backup_criteria = $_SESSION['glpisearch']['Computer'];
         }
 
-
         switch ($tabnum) {
             case 1:
                 self::showCriteriaAndSearch($item);
@@ -157,7 +156,6 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
                 return true;
 
             case 2:
-
                 $pagination_params = [];
                 foreach (['sort', 'order', 'start'] as $field) {
                     if (isset($_SESSION['glpisearch']['Computer'][$field])) {
@@ -175,10 +173,8 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
                 }
                 $params['target'] = PluginGlpiinventoryDeployGroup::getSearchEngineTargetURL($_GET['id'], true);
                 self::showList('Computer', $params, []);
-
                 //restore session data
                 $_SESSION['glpisearch']['Computer'] = $backup_criteria;
-
                 return true;
         }
         return false;
@@ -214,7 +210,6 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
         PluginGlpiinventoryDeployGroup::showCriteria($item, $search_params);
         echo '</div>';
         echo '</div>';
-
     }
 
 

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -201,8 +201,6 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
        //and it is not we want !
        unset($search_params['reset']);
 
-       Toolbox::logDebug($_SESSION['glpisearch']['Computer']['criteria'] = $search_params['criteria']);
-
         if (isset($search_params['metacriteria']) && empty($search_params['metacriteria'])) {
             unset($search_params['metacriteria']);
         }

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -195,11 +195,13 @@ class PluginGlpiinventoryDeployGroup_Dynamicdata extends CommonDBChild
                 $pagination_params[$field] = $_SESSION['glpisearch']['Computer'][$field];
             }
         }
-       // WITHOUT checking post values
+        // WITHOUT checking post values
         $search_params = PluginGlpiinventoryDeployGroup::getSearchParamsAsAnArray($item, false);
-       //If metacriteria array is empty, remove it as it displays the metacriteria form,
-       //and it is not we want !
-       unset($search_params['reset']);
+        //If metacriteria array is empty, remove it as it displays the metacriteria form,
+        //and it is not we want !
+        unset($search_params['reset']);
+
+        $_SESSION['glpisearch']['Computer']['criteria'] = $search_params['criteria'];
 
         if (isset($search_params['metacriteria']) && empty($search_params['metacriteria'])) {
             unset($search_params['metacriteria']);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It's necessary to do a backup of $_SESSION['glpisearch']['Computer']
to isolate the search performed in the dynamic group,
otherwise the search will be reused by GLPI in the computer list (from $_SESSION['glpisearch']['Computer'])

Fix !34851

## Screenshots (if appropriate):

