### PR TITLE
fix: Data too long for column value

### DIFF
--- a/install/mysql/plugin_glpiinventory-empty.sql
+++ b/install/mysql/plugin_glpiinventory-empty.sql
@@ -486,7 +486,7 @@ CREATE TABLE `glpi_plugin_glpiinventory_collects_registries_contents` (
   `computers_id` int unsigned NOT NULL DEFAULT '0',
   `plugin_glpiinventory_collects_registries_id` int unsigned NOT NULL DEFAULT '0',
   `key` varchar(255) DEFAULT NULL,
-  `value` varchar(255) DEFAULT NULL,
+  `value` text DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `computers_id` (`computers_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/install/update.php
+++ b/install/update.php
@@ -1089,6 +1089,14 @@ function pluginGlpiinventoryUpdate($current_version, $migrationname = 'Migration
         ], "glpiinventory");
     }
 
+    // Change
+    $migration->changeField(
+        'glpi_plugin_glpiinventory_collects_registries_contents',
+        'value',
+        'value',
+        'text DEFAULT NULL'
+    );
+
     $migration->executeMigration();
 }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35412
- Here is a brief description of what this PR does

Fix SQL error:

```
glpisqllog.ERROR: DBmysql::doQuery() in /data/sites/glpiadm/src/DBmysql.php line 403
  *** MySQL query error:
  SQL: INSERT INTO `glpi_plugin_glpiinventory_collects_registries_contents` (`computers_id`, `plugin_glpiinventory_collects_registries_id`, `key`, `value`) VALUES ('****', '****', '****', '************************************')
  Error: Data too long for column 'value' at row 1
  Backtrace :
  src/DBmysql.php:1380                               DBmysql->doQuery()
  src/CommonDBTM.php:729                             DBmysql->insert()
  src/CommonDBTM.php:1342                            CommonDBTM->addToDB()
  ...tory/inc/collect_registry_content.class.php:143 CommonDBTM->add()
  plugins/glpiinventory/inc/collect.class.php:811    PluginGlpiinventoryCollect_Registry_Content->updateComputer()
  plugins/glpiinventory/b/collect/index.php:42       PluginGlpiinventoryCollect->communication()
```

## Screenshots (if appropriate):

