### PR TITLE
fix(taskjob): entities_id cannot be null

### DIFF
--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -928,7 +928,7 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
             Session::checkRight('plugin_glpiinventory_task', CREATE);
             if (isset($postvars['add'])) {
                 if (!isset($postvars['entities_id'])) {
-                    $postvars['entities_id'] = $_SESSION['glpidefault_entity'];
+                    $postvars['entities_id'] = $_SESSION['glpidefault_entity'] ?? 0;
                 }
                // Get entity of task
                 $pfTask = new PluginGlpiinventoryTask();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Prevent SQL error
```
glpisqllog.ERROR: DBmysql::doQuery() in /home/ubuntu/Dev/GLPI/10.0-bugfixes/src/DBmysql.php line 395
  *** MySQL query error:
  SQL: INSERT INTO `glpi_plugin_glpiinventory_taskjobs` (`plugin_glpiinventory_tasks_id`, `name`, `comment`, `method`, `restrict_to_task_entity`, `entities_id`, `date_creation`) VALUES ('1', 'discovery', '', 'networkdiscovery', '0', NULL, '2024-12-05 07:42:06')
  Error: Column 'entities_id' cannot be null
  Backtrace :
  src/DBmysql.php:1376                               DBmysql->doQuery()
  src/CommonDBTM.php:730                             DBmysql->insert()
  src/CommonDBTM.php:1349                            CommonDBTM->addToDB()
  ...ins/glpiinventory/inc/taskjobview.class.php:940 CommonDBTM->add()
  plugins/glpiinventory/front/taskjob.form.php:48    PluginGlpiinventoryTaskjobView->submitForm()
  public/index.php:82                                require()
```

_As a reminder, since 10.0.17, `default_entity` can be NULL (https://github.com/glpi-project/glpi/pull/18132)_
