### PR TITLE
Fix collect registries content limit

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -6934,7 +6934,7 @@ function do_collect_migration($migration)
                                                 'value'   => null];
     $a_table['fields']['key']       = ['type'    => 'string',
                                              'value'   => null];
-    $a_table['fields']['value']     = ['type'    => 'string',
+    $a_table['fields']['value']     = ['type'    => 'text',
                                              'value'   => null];
 
     $a_table['oldfields']  = [];

--- a/install/update.php
+++ b/install/update.php
@@ -1089,14 +1089,6 @@ function pluginGlpiinventoryUpdate($current_version, $migrationname = 'Migration
         ], "glpiinventory");
     }
 
-    // Change
-    $migration->changeField(
-        'glpi_plugin_glpiinventory_collects_registries_contents',
-        'value',
-        'value',
-        'text DEFAULT NULL'
-    );
-
     $migration->executeMigration();
 }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35638
- Here is a brief description of what this PR does

A collection task only receives values of 255 characters, whereas the registry key can contain more. This causes errors for some customers

## Screenshots (if appropriate):

