### PR TITLE
fix: PHP error - allowed memory size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+
 - Ensure that the `Taskjob` identifier is used to extract the device IP.
 - Isolate dynamic group criteria to prevent their global reapplication in GLPI.
+- Fixes memory exhaustion when "extra-debug" is disabled
 
 ## [1.4.0] - 2024-09-06
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -1332,19 +1332,21 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
         session_write_close();
 
         $logs = $this->getJoblogs($task_ids, true, false);
-        PluginGlpiinventoryToolbox::logIfExtradebug(
-            "pluginGlpiinventory-tasks",
-            "ajaxGetJobLogs, agents: " . count($logs['agents'])
-        );
-        PluginGlpiinventoryToolbox::logIfExtradebug(
-            "pluginGlpiinventory-tasks",
-            "ajaxGetJobLogs, tasks: " . count($logs['tasks'])
-        );
+        if (PluginGlpiinventoryConfig::isExtradebugActive()) {
+            PluginGlpiinventoryToolbox::logIfExtradebug(
+                "pluginGlpiinventory-tasks",
+                "ajaxGetJobLogs, agents: " . count($logs['agents'])
+            );
+            PluginGlpiinventoryToolbox::logIfExtradebug(
+                "pluginGlpiinventory-tasks",
+                "ajaxGetJobLogs, tasks: " . count($logs['tasks'])
+            );
 
-        PluginGlpiinventoryToolbox::logIfExtradebug(
-            "pluginGlpiinventory-tasks",
-            "ajaxGetJobLogs: " . print_r($logs, true)
-        );
+            PluginGlpiinventoryToolbox::logIfExtradebug(
+                "pluginGlpiinventory-tasks",
+                "ajaxGetJobLogs: " . print_r($logs, true)
+            );
+        }
         $out = json_encode($logs);
         if (
             isset($options['display'])


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35468
- Here is a brief description of what this PR does

Prevent this type of error message :
```
glpiphplog.CRITICAL:   *** PHP Error (1): Allowed memory size of 268435456 bytes exhausted (tried to allocate 48238592 bytes) in /data/glpi/plugins/glpiinventory/inc/task.class.php at line 1347
```

The `logIfExtradebug()` function is used to log data when the "extra-debug" option is enabled. However, when the data size is very large and this option is disabled, it triggers a memory exhaustion error when the function is called, even though the function itself does nothing.

## Screenshots (if appropriate):

