### PR TITLE
Fix SNMP communication error (wrong tasks id gived)

### DIFF
--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -367,7 +367,10 @@ class PluginGlpiinventoryNetworkinventory extends PluginGlpiinventoryCommunicati
         $current = $jobstate;
         $agent->getFromDB($current->fields['agents_id']);
 
-        $ip = $this->getDeviceIPOfTaskID($jobstate->fields['itemtype'], $jobstate->fields['items_id'], $jobstate->fields['plugin_glpiinventory_taskjobs_id']);
+        $taskjob = new PluginGlpiinventoryTaskjob();
+        $taskjob->getFromDB($jobstate->fields['plugin_glpiinventory_taskjobs_id']);
+
+        $ip = $this->getDeviceIPOfTaskID($jobstate->fields['itemtype'], $jobstate->fields['items_id'], $taskjob->fields['plugin_glpiinventory_tasks_id']);
 
         $param_attrs = [];
         $device_attrs = [];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35754
- Here is a brief description of what this PR does

Previously, the value used when calling the `getDeviceIPOfTaskID` method was the taskjob id, but the requested value was the task id, 

## Screenshots (if appropriate):

