### PR TITLE
Translate error messages for end user

### DIFF
--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -479,7 +479,7 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
             if ($result['task']['is_active'] == 0) {
                 $msg = "The task has been deactivated after preparation of this job.";
                 $translatable_msg = __("The task has been deactivated after preparation of this job.", 'glpiinventory');
-                
+
                 $jobstates_to_cancel[$jobstate->fields['id']] = [
                 'jobstate' => $jobstate,
                 'reason'   => $msg

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -464,9 +464,12 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
                 $result['run']['state'] == PluginGlpiinventoryTaskjobstate::SERVER_HAS_SENT_DATA
                  or $result['run']['state'] == PluginGlpiinventoryTaskjobstate::AGENT_HAS_SENT_DATA
             ) {
+                $msg = "The agent is requesting a configuration that has already been sent to him by the server. It is more likely that the agent is subject to a critical error.";
+                $translatable_msg = __("The agent is requesting a configuration that has already been sent to him by the server. It is more likely that the agent is subject to a critical error.", 'glpiinventory');
+
                 $jobstates_to_cancel[$jobstate->fields['id']] = [
                 'jobstate' => $jobstate,
-                'reason'   => "The agent is requesting a configuration that has already been sent to him by the server. It is more likely that the agent is subject to a critical error.",
+                'reason'   => $msg,
                 'code'     => $jobstate::IN_ERROR
                 ];
                 continue;
@@ -474,9 +477,12 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
 
            // Cancel the jobstate if the related tasks has been deactivated
             if ($result['task']['is_active'] == 0) {
+                $msg = "The task has been deactivated after preparation of this job.";
+                $translatable_msg = __("The task has been deactivated after preparation of this job.", 'glpiinventory');
+                
                 $jobstates_to_cancel[$jobstate->fields['id']] = [
                 'jobstate' => $jobstate,
-                'reason'   => "The task has been deactivated after preparation of this job."
+                'reason'   => $msg
                 ];
                 continue;
             };
@@ -492,9 +498,12 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
                 }
 
                 if (!($schedule_start <= $now and $now <= $schedule_end)) {
+                    $msg = "This job can not be executed anymore due to the task's schedule.";
+                    $translatable_msg = __("This job can not be executed anymore due to the task's schedule.", 'glpiinventory');
+
                     $jobstates_to_cancel[$jobstate->fields['id']] = [
                     'jobstate' => $jobstate,
-                    'reason'   => "This job can not be executed anymore due to the task's schedule."
+                    'reason'   => $msg
                     ];
                     continue;
                 }
@@ -536,9 +545,12 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
 
                // If no timeslot matched, cancel this jobstate.
                 if (!$timeslot_matched) {
+                    $msg = "This job can not be executed anymore due to the task's timeslot.";
+                    $translatable_msg = __("This job can not be executed anymore due to the task's timeslot.", 'glpiinventory');
+
                     $jobstates_to_cancel[$jobstate->fields['id']] = [
                     'jobstate' => $jobstate,
-                    'reason'   => "This job can not be executed anymore due to the task's timeslot."
+                    'reason'   => $msg
                     ];
                     continue;
                 }
@@ -552,9 +564,12 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
 
            //$job_actors = importArrayFromDB($result['job']['actors']);
             if (!in_array($agent_id, $agents)) {
+                $msg = "This agent does not belong anymore in the actors defined in the job.";
+                $translatable_msg = __("This agent does not belong anymore in the actors defined in the job.", 'glpiinventory');
+
                 $jobstates_to_cancel[$jobstate->fields['id']] = [
                 'jobstate' => $jobstate,
-                'reason'   => "This agent does not belong anymore in the actors defined in the job."
+                'reason'   => $msg
                 ];
                 continue;
             }

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -466,11 +466,8 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
             ) {
                 $jobstates_to_cancel[$jobstate->fields['id']] = [
                 'jobstate' => $jobstate,
-                'reason'   => __(
-                    "The agent is requesting a configuration that has already been sent to him by the server. It is more likely that the agent is subject to a critical error.",
-                    'glpiinventory'
-                ),
-                 'code'     => $jobstate::IN_ERROR
+                'reason'   => "The agent is requesting a configuration that has already been sent to him by the server. It is more likely that the agent is subject to a critical error.",
+                'code'     => $jobstate::IN_ERROR
                 ];
                 continue;
             }
@@ -479,10 +476,7 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
             if ($result['task']['is_active'] == 0) {
                 $jobstates_to_cancel[$jobstate->fields['id']] = [
                 'jobstate' => $jobstate,
-                'reason'   => __(
-                    'The task has been deactivated after preparation of this job.',
-                    'glpiinventory'
-                )
+                'reason'   => "The task has been deactivated after preparation of this job."
                 ];
                 continue;
             };
@@ -500,10 +494,7 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
                 if (!($schedule_start <= $now and $now <= $schedule_end)) {
                     $jobstates_to_cancel[$jobstate->fields['id']] = [
                     'jobstate' => $jobstate,
-                    'reason'   => __(
-                        "This job can not be executed anymore due to the task's schedule.",
-                        'glpiinventory'
-                    )
+                    'reason'   => "This job can not be executed anymore due to the task's schedule."
                     ];
                     continue;
                 }
@@ -547,10 +538,7 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
                 if (!$timeslot_matched) {
                     $jobstates_to_cancel[$jobstate->fields['id']] = [
                     'jobstate' => $jobstate,
-                    'reason'   => __(
-                        "This job can not be executed anymore due to the task's timeslot.",
-                        'glpiinventory'
-                    )
+                    'reason'   => "This job can not be executed anymore due to the task's timeslot."
                     ];
                     continue;
                 }
@@ -566,10 +554,7 @@ class PluginGlpiinventoryTask extends PluginGlpiinventoryTaskView
             if (!in_array($agent_id, $agents)) {
                 $jobstates_to_cancel[$jobstate->fields['id']] = [
                 'jobstate' => $jobstate,
-                'reason'   => __(
-                    'This agent does not belong anymore in the actors defined in the job.',
-                    'glpiinventory'
-                )
+                'reason'   => "This agent does not belong anymore in the actors defined in the job."
                 ];
                 continue;
             }

--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -423,7 +423,7 @@ function agents_chart(chart_id) {
                            "<tr class='run log'>" +
                            "<td>" + log['log.date'] +"</td>"+
                            "<td>" + taskjobs.logstatuses_names[log['log.state']] +"</td>"+
-                           "<td class='comment'>" + log['log.comment'] +"</td>"+
+                           "<td class='comment'>" + __(log['log.comment'], 'glpiinventory') +"</td>"+
                            "</tr>"
                         );
                       });

--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -423,7 +423,7 @@ function agents_chart(chart_id) {
                            "<tr class='run log'>" +
                            "<td>" + log['log.date'] +"</td>"+
                            "<td>" + taskjobs.logstatuses_names[log['log.state']] +"</td>"+
-                           "<td class='comment'>" + __(log['log.comment'], 'glpiinventory') +"</td>"+
+                           "<td class='comment'>" + log['log.comment'] +"</td>"+
                            "</tr>"
                         );
                       });
@@ -470,22 +470,17 @@ taskjobs.update_agents_view = function (chart_id) {
       filtered_agents = filtered_agents.map(function(d) { return [d,true]; } ).toObject();
 
       var total_agents_to_view = chart.agents.reject( function(d) {
-         //remove pinned agents from the list since we concat them next.
-         if ( chart.pinned_agents[d[0]] ) {
-            return true;
-         }
-         if ( filtered_agents[d[0]] ) {
-            return false;
-         } else {
-            return true;
-         }
-      });
-
-      var agents_to_view = Lazy(pinned_agents.toArray()).concat(total_agents_to_view.toArray()).first(chart.view_limit);
+            if ( filtered_agents[d[0]] ) {
+                return false;
+            } else {
+                return true;
+            }
+        });
+      var agents_to_view = Lazy(total_agents_to_view.toArray()).first(chart.view_limit);
 
       taskjobs.agents_chart[chart_id].filtered_agents = filtered_agents;
       taskjobs.agents_chart[chart_id].agents_to_view = agents_to_view.toArray();
-      taskjobs.agents_chart[chart_id].total_agents_to_view = total_agents_to_view.size() + pinned_agents.size();
+      taskjobs.agents_chart[chart_id].total_agents_to_view = total_agents_to_view.size();
       taskjobs.agents_chart[chart_id].debug = total_agents_to_view;
    }
    taskjobs.agents_chart[chart_id].display_agents = true;
@@ -502,9 +497,6 @@ taskjobs.display_agents_view = function(chart_id) {
       .call(agents_chart(chart_id));
 
       var agents_hidden = chart.total_agents_to_view - agents.length;
-      if (agents_hidden <= 0) {
-         taskjobs.agents_chart[chart_id].view_limit = 10;
-      }
       var limit_to_add = 10;
       var button_text = [];
       if (agents_hidden > 0) {

--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -423,7 +423,7 @@ function agents_chart(chart_id) {
                            "<tr class='run log'>" +
                            "<td>" + log['log.date'] +"</td>"+
                            "<td>" + taskjobs.logstatuses_names[log['log.state']] +"</td>"+
-                           "<td class='comment'>" + log['log.comment'] +"</td>"+
+                           "<td class='comment'>" + __(log['log.comment'], 'glpiinventory') +"</td>"+
                            "</tr>"
                         );
                       });
@@ -470,17 +470,22 @@ taskjobs.update_agents_view = function (chart_id) {
       filtered_agents = filtered_agents.map(function(d) { return [d,true]; } ).toObject();
 
       var total_agents_to_view = chart.agents.reject( function(d) {
-            if ( filtered_agents[d[0]] ) {
-                return false;
-            } else {
-                return true;
-            }
-        });
-      var agents_to_view = Lazy(total_agents_to_view.toArray()).first(chart.view_limit);
+         //remove pinned agents from the list since we concat them next.
+         if ( chart.pinned_agents[d[0]] ) {
+            return true;
+         }
+         if ( filtered_agents[d[0]] ) {
+            return false;
+         } else {
+            return true;
+         }
+      });
+
+      var agents_to_view = Lazy(pinned_agents.toArray()).concat(total_agents_to_view.toArray()).first(chart.view_limit);
 
       taskjobs.agents_chart[chart_id].filtered_agents = filtered_agents;
       taskjobs.agents_chart[chart_id].agents_to_view = agents_to_view.toArray();
-      taskjobs.agents_chart[chart_id].total_agents_to_view = total_agents_to_view.size();
+      taskjobs.agents_chart[chart_id].total_agents_to_view = total_agents_to_view.size() + pinned_agents.size();
       taskjobs.agents_chart[chart_id].debug = total_agents_to_view;
    }
    taskjobs.agents_chart[chart_id].display_agents = true;
@@ -497,6 +502,9 @@ taskjobs.display_agents_view = function(chart_id) {
       .call(agents_chart(chart_id));
 
       var agents_hidden = chart.total_agents_to_view - agents.length;
+      if (agents_hidden <= 0) {
+         taskjobs.agents_chart[chart_id].view_limit = 10;
+      }
       var limit_to_add = 10;
       var button_text = [];
       if (agents_hidden > 0) {

--- a/tests/Integration/Tasks/CronTaskTest.php
+++ b/tests/Integration/Tasks/CronTaskTest.php
@@ -694,7 +694,6 @@ class CronTaskTest extends TestCase
         //Set the first job as successfull
         $iterator = $DB->request([
             'FROM' => 'glpi_plugin_glpiinventory_taskjoblogs',
-            'ORDER' => 'id',
             'LIMIT' => 1
         ]);
         foreach ($iterator as $data) {

--- a/tests/Integration/Tasks/CronTaskTest.php
+++ b/tests/Integration/Tasks/CronTaskTest.php
@@ -694,6 +694,7 @@ class CronTaskTest extends TestCase
         //Set the first job as successfull
         $iterator = $DB->request([
             'FROM' => 'glpi_plugin_glpiinventory_taskjoblogs',
+            'ORDER' => 'id',
             'LIMIT' => 1
         ]);
         foreach ($iterator as $data) {


### PR DESCRIPTION
The plug-in stores the error message based on the current user language. This PR stores the message on English and translates the message on the client side, so on GLPI instances with multilanguage user, the task log will show the error message based on the current user language instead of the language of the user that the error message has been generated.

Before this PR, an Portuguese language user was seeing error messages on English:

![image](https://github.com/user-attachments/assets/01454c1b-9b26-42dc-896a-d32b21e2f9ab)

After this PR, a Portuguese Language user can see error messages in their native language independent of the language of the user that the error has been generated:

![image](https://github.com/user-attachments/assets/4d6a9bda-666a-4664-9c70-a1c6dba1814b)

Edit: The only known issue I can think of this PR can cause is that those strings would be removed from the POT file, so I believe it would need a way to keep them there or do a dummy call/register of them into JS/PHP code (maybe a fake/unused property of the same object that I modified into this PR) so they would be gathered by Transiflex bot and wouldn't be missing.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

