### PR TITLE
Do not list agentless agents on Actor Taskdropdown

### DIFF
--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -430,7 +430,8 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
             $iterator = $DB->request([
                 'SELECT' => [
                     'agents.id AS agents_id',
-                    'agents.items_id'
+                    'agents.items_id',
+                    'agents.version'
                 ],
                 'FROM' => 'glpi_agents AS agents',
                 'LEFT JOIN' => [
@@ -456,7 +457,8 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
                         'UPPER(modules.modulename)' => $modulename,
                     ],
                     'computers.is_deleted' => 0,
-                    'computers.is_template' => 0
+                    'computers.is_template' => 0,
+                    'NOT' => ['version' => null]
                 ],
                 'GROUP' => [
                     'agents.id',


### PR DESCRIPTION
After a successful ESX inventory task, an agent is created on GLPI. Into https://github.com/glpi-project/glpi-agent/discussions/832 I discussed with @g-bougard about this behavior (the reasons and possible workarounds that could be implemented on the GLPI-Agent is discussed there). He said that it's an inherited behavior from FusionInventory Agent and I should open an issue on GLPI-Inventory plugin. From GLPI server point-of-view, doesn't seems to be a way for it to determine that it's an agentless inventory instead of a inventory of a real machine and for this reason it seems to create an agent. I don't see any problem with it at all, but when creating tasks, those agentless agents are shown into the dropdown of task actors, but they doesn't have any capability to run those tasks. Into the ``glpi.agents`` DB, the only way I could find to differentiate those agentless agents are using the ``version`` and ``use_module_*`` columns. Since the ``version`` column of these agents are NULL, we can use it to hide those agentless agents as task actors. Other possible solutions for this is using the ``use_module_*`` column, which would allows us to be much more specific about the filter and features that an agent is capable of. We could improve the method ``isAgentCanDo`` to also fetch the value of those columns and only return ``true`` if the module is enabled (current behavior) and also if it's installed on the agent. The ``getAgentsCanDo`` also returns information about the agents and maybe could be used to replace this SQL query, and the ``use_module_*`` values are also available into the returned array object that could be checked.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

