### PR TITLE
Fix escape on log.comments (taskjob.js)

### DIFF
--- a/inc/taskjoblog.class.php
+++ b/inc/taskjoblog.class.php
@@ -374,6 +374,6 @@ class PluginGlpiinventoryTaskjoblog extends CommonDBTM
                 $comment = str_replace($commentvalue, $a_text[$matches[1][$num]], $comment);
             }
         }
-        return str_replace(",[", "<br/>[", $comment);
+        return str_replace([",[", "\\'"], ["<br/>[", "'"], $comment);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

Before this PR on task log:

![image](https://github.com/user-attachments/assets/8144cb22-5b65-45c3-9dcb-eda48fb9fbb8)

After this PR on task log:

![image](https://github.com/user-attachments/assets/389590e9-38dc-4768-914b-2abb5a2c3457)

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

