### PR TITLE
Fix translation of Task Status

### DIFF
--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -228,11 +228,11 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
          };
 
          taskjobs.statuses_names = {
-            'agents_error':     '" . __('In error', 'glpiinventory') . "',
-            'agents_success':   '" . __('Successful', 'glpiinventory') . "',
-            'agents_running':   '" . __('Running', 'glpiinventory') . "',
-            'agents_prepared':  '" . __('Prepared', 'glpiinventory') . "',
-            'agents_cancelled': '" . __('Cancelled', 'glpiinventory') . "',
+            'agents_error':     'In error',
+            'agents_success':   'Successful',
+            'agents_running':   'Running',
+            'agents_prepared':  'Prepared',
+            'agents_cancelled': 'Cancelled'
          };
 
          taskjobs.logstatuses_names = " .


### PR DESCRIPTION
## Checklist before requesting a review

Now when switching between languages it translates the task statuses to reflect the current user language.

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

