### PR TITLE
Improve translation

### DIFF
--- a/inc/taskjoblog.class.php
+++ b/inc/taskjoblog.class.php
@@ -347,6 +347,8 @@ class PluginGlpiinventoryTaskjoblog extends CommonDBTM
     public static function convertComment($comment)
     {
         $matches = [];
+       // Attempt to translate fixed strings (e.g. error messages, see PR#601)
+        $comment = __($comment, 'glpiinventory');
        // Search for replace [[itemtype::items_id]] by link
         preg_match_all("/\[\[(.*)\:\:(.*)\]\]/", $comment, $matches);
         foreach ($matches[0] as $num => $commentvalue) {
@@ -354,7 +356,7 @@ class PluginGlpiinventoryTaskjoblog extends CommonDBTM
             if ($classname != '' && class_exists($classname)) {
                 $Class = new $classname();
                 $Class->getFromDB($matches[2][$num]);
-                $comment = str_replace($commentvalue, $Class->getLink(), $comment);
+                $comment = $Class->getTypeName() + " " + str_replace($commentvalue, $Class->getLink(), $comment);
             }
         }
         if (strstr($comment, "==")) {


### PR DESCRIPTION
This is a revision of PR#601. When translating on client-side, the translation may fail for some items (e.g. "updatetheitem" strings) because it creates a string on-the-fly (e.g. "Update the item Computer", "Update the item Network Device"). Also, when translating on client-side, it creates some artifacts when calling the ``$Class->getLink()`` call because the link are escaped and isn't rendered as HTML on client-side.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

