### PR TITLE
Fix PHP warnings on Deploy Package

### DIFF
--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -146,7 +146,7 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
     {
 
         $actions = [];
-        if (strstr($_SERVER["HTTP_REFERER"], 'deploypackage.import.php')) {
+        if (isset($_SERVER["HTTP_REFERER"]) && strstr($_SERVER["HTTP_REFERER"], 'deploypackage.import.php')) {
             $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'import'] = __('Import', 'glpiinventory');
         } else {
             $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'transfert'] = __('Transfer');
@@ -166,7 +166,7 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
     public function getForbiddenStandardMassiveAction()
     {
         $forbidden = parent::getForbiddenStandardMassiveAction();
-        if (strstr($_SERVER["HTTP_REFERER"], 'deploypackage.import.php')) {
+        if (isset($_SERVER["HTTP_REFERER"]) && strstr($_SERVER["HTTP_REFERER"], 'deploypackage.import.php')) {
             $forbidden[] = 'update';
             $forbidden[] = 'add';
             $forbidden[] = 'delete';

--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -166,7 +166,7 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
     public function getForbiddenStandardMassiveAction()
     {
         $forbidden = parent::getForbiddenStandardMassiveAction();
-        if (isset($_SERVER["HTTP_REFERER"]) && strstr($_SERVER["HTTP_REFERER"], 'deploypackage.import.php')) {
+        if (strstr($_SERVER["HTTP_REFERER"] ?? '', 'deploypackage.import.php')) {
             $forbidden[] = 'update';
             $forbidden[] = 'add';
             $forbidden[] = 'delete';

--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -146,7 +146,7 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
     {
 
         $actions = [];
-        if (isset($_SERVER["HTTP_REFERER"]) && strstr($_SERVER["HTTP_REFERER"], 'deploypackage.import.php')) {
+        if (strstr($_SERVER["HTTP_REFERER"] ?? '', 'deploypackage.import.php')) {
             $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'import'] = __('Import', 'glpiinventory');
         } else {
             $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'transfert'] = __('Transfer');


### PR DESCRIPTION
When opening a package to edit and into another tab switch the profile to Self-Service (or any other profile which doesn't have access to Deploy Package page) it throws a PHP Warning on page if display errors is enabled on PHP settings.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/969a3422-104e-47e5-97f5-1fb65dc04681)
