### PR TITLE
Improve isAgentCanDo() to check module installed flags

### DIFF
--- a/inc/agentmodule.class.php
+++ b/inc/agentmodule.class.php
@@ -402,7 +402,9 @@ class PluginGlpiinventoryAgentmodule extends CommonDBTM
 
         if ($agentModule['is_active'] == 0) {
             if (in_array($agents_id, $a_agentExceptList)) {
-                if (isset($module_active) && count($a_agentModList) == 0) return false;
+                if (isset($module_active) && count($a_agentModList) == 0) {
+                    return false;
+                }
                 return true;
             } else {
                 return false;
@@ -411,7 +413,9 @@ class PluginGlpiinventoryAgentmodule extends CommonDBTM
             if (in_array($agents_id, $a_agentExceptList) && count($a_agentModList) > 0) {
                 return false;
             } else {
-                if (isset($module_active) && count($a_agentModList) == 0) return false;
+                if (isset($module_active) && count($a_agentModList) == 0) {
+                    return false;
+                }
                 return true;
             }
         }

--- a/inc/agentmodule.class.php
+++ b/inc/agentmodule.class.php
@@ -410,7 +410,7 @@ class PluginGlpiinventoryAgentmodule extends CommonDBTM
                 return false;
             }
         } else {
-            if (in_array($agents_id, $a_agentExceptList) && count($a_agentModList) > 0) {
+            if (in_array($agents_id, $a_agentExceptList)) {
                 return false;
             } else {
                 if (isset($module_active) && count($a_agentModList) == 0) {

--- a/inc/agentmodule.class.php
+++ b/inc/agentmodule.class.php
@@ -373,20 +373,45 @@ class PluginGlpiinventoryAgentmodule extends CommonDBTM
     public function isAgentCanDo($module_name, $agents_id)
     {
 
+        switch (strtoupper($module_name)) {
+            case "INVENTORYCOMPUTERESX":
+                $module_active = "use_module_esx_remote_inventory";
+                break;
+            case "NETWORKDISCOVERY":
+                $module_active = "use_module_network_discovery";
+                break;
+            case "NETWORKINVENTORY":
+                $module_active = "use_module_network_inventory";
+                break;
+            case "DEPLOY":
+                $module_active = "use_module_package_deployment";
+                break;
+            case "COLLECT":
+                $module_active = "use_module_collect_data";
+                break;
+        }
+
+        $a_agentModList = [];
+        if (isset($module_active)) {
+            $agent = new Agent();
+            $a_agentModList = $agent->find(['id' => $agents_id, $module_active => 1]);
+        }
+
         $agentModule = $this->getActivationExceptions($module_name);
+        $a_agentExceptList = importArrayFromDB($agentModule['exceptions']);
 
         if ($agentModule['is_active'] == 0) {
-            $a_agentList = importArrayFromDB($agentModule['exceptions']);
-            if (in_array($agents_id, $a_agentList)) {
+            if (in_array($agents_id, $a_agentExceptList)) {
+                if (isset($module_active) && count($a_agentModList) == 0) return false;
                 return true;
             } else {
                 return false;
             }
         } else {
-            $a_agentList = importArrayFromDB($agentModule['exceptions']);
-            if (in_array($agents_id, $a_agentList)) {
+            if (in_array($agents_id, $a_agentExceptList) && count($a_agentModList) > 0) {
                 return false;
             } else {
+                if (isset($module_active) && count($a_agentModList) == 0) return false;
                 return true;
             }
         }

--- a/tests/Integration/CollectsTest.php
+++ b/tests/Integration/CollectsTest.php
@@ -277,7 +277,8 @@ class CollectsTest extends TestCase
           'itemtype'     => Computer::getType(),
           'items_id'     => $computers_id,
           'deviceid'     => 'pc01',
-         'agenttypes_id' => $agenttype['id']
+          'agenttypes_id' => $agenttype['id'],
+          'use_module_collect_data' => 1
         ];
         $agents_id = $agent->add($input);
         $this->assertNotFalse($agents_id);

--- a/tests/Integration/Deploy/PackageSelfDeployTest.php
+++ b/tests/Integration/Deploy/PackageSelfDeployTest.php
@@ -97,7 +97,8 @@ class PackageSelfDeployTest extends TestCase
          'items_id' => $computerId,
          'entities_id' => 0,
          'agenttypes_id' => $agenttype['id'],
-         'deviceid' => "Computer$computerId"
+         'deviceid' => "Computer$computerId",
+         'use_module_package_deployment' => 1
         ]);
         $pfDeployGroup->add([
          'name' => 'all',

--- a/tests/Integration/Deploy/PackageSelfDeployTest.php
+++ b/tests/Integration/Deploy/PackageSelfDeployTest.php
@@ -378,7 +378,8 @@ class PackageSelfDeployTest extends TestCase
          'items_id' => $computerId2,
          'entities_id' => 0,
          'agenttypes_id' => $agenttype['id'],
-         'deviceid' => "Computer$computerId2"
+         'deviceid' => "Computer$computerId2",
+         'use_module_package_deployment' => 1
         ]);
         $this->assertNotFalse($agentId);
 
@@ -463,7 +464,8 @@ class PackageSelfDeployTest extends TestCase
          'items_id' => $computerId3,
          'entities_id' => 0,
          'agenttypes_id' => $agenttype['id'],
-         'deviceid' => "Computer$computerId3"
+         'deviceid' => "Computer$computerId3",
+         'use_module_package_deployment' => 1
         ]);
 
         $pfDeployPackage->getFromDBByCrit(['name' => 'test1']);

--- a/tests/Integration/RestURLTest.php
+++ b/tests/Integration/RestURLTest.php
@@ -84,7 +84,8 @@ class RestURLTest extends TestCase
          'deviceid'   => 'toto-device',
          'agenttypes_id' => $agenttype['id'],
          'itemtype' => '',
-         'items_id' => 0
+         'items_id' => 0,
+         'use_module_collect_data' => 1
         ];
         $agents_id = $agent->add($input);
         $this->assertNotFalse($agents_id);

--- a/tests/Integration/RestURLTest.php
+++ b/tests/Integration/RestURLTest.php
@@ -85,7 +85,9 @@ class RestURLTest extends TestCase
          'agenttypes_id' => $agenttype['id'],
          'itemtype' => '',
          'items_id' => 0,
-         'use_module_collect_data' => 1
+         'use_module_collect_data' => 1,
+         'use_module_package_deployment' => 1,
+         'use_module_esx_remote_inventory' => 1
         ];
         $agents_id = $agent->add($input);
         $this->assertNotFalse($agents_id);

--- a/tests/Unit/Deploy/DeploypackageTest.php
+++ b/tests/Unit/Deploy/DeploypackageTest.php
@@ -78,7 +78,8 @@ class DeploypackageTest extends TestCase
           'useragent'   => 'FusionInventory-Agent_v2.3.21',
           'itemtype' => Computer::getType(),
           'items_id' => $computers_id,
-          'agenttypes_id' => $agenttype['id']
+          'agenttypes_id' => $agenttype['id'],
+          'use_module_package_deployment' => 1
         ];
         $this->assertNotFalse($agent->add($input));
 


### PR DESCRIPTION
By default, the Deploy Package uses ``isAgentCanDo()`` function to determine which hosts to install a package, but it was also offering to install packages on ESXi remove inventory hosts which doesn't have the Deploy module installed. This PR ensures that a host which doesn't have a module installed be available to select packages to install.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

