### PR TITLE
fix: Alignment of 'Cancel modifications' button on taskjob

### DIFF
--- a/css/views.css
+++ b/css/views.css
@@ -258,10 +258,6 @@ td:not(#foo) > input[type=radio]:checked + label {
    font-weight: bolder;
 }
 
-#cancel_job_changes_button {
-  float: left;
-}
-
 /* Logs monitoring styles */
 
 .jobs_block {

--- a/css/views.css
+++ b/css/views.css
@@ -258,6 +258,10 @@ td:not(#foo) > input[type=radio]:checked + label {
    font-weight: bolder;
 }
 
+#cancel_job_changes_button {
+  float: left;
+}
+
 /* Logs monitoring styles */
 
 .jobs_block {

--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -774,6 +774,12 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
         } else {
             echo "<tr>";
             echo "<td class='right' colspan='4'>";
+            echo "<button type='button' id='cancel_job_changes_button' style='display:none'
+                             class='btn btn-outline-secondary me-2'
+                             onclick='taskjobs.edit(\"" . $this->getBaseUrlFor('fi.job.edit') . "\", $id)'>" .
+                             __('Cancel modifications', 'glpiinventory') . "
+                   </button>&nbsp;";
+
             echo "<input type='submit'
                       name='delete'
                       value=\"" . __('Purge', 'glpiinventory') . "\"
@@ -782,12 +788,6 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
                           'Confirm the final deletion ?',
                           'glpiinventory'
                       )) . ">&nbsp;";
-
-            echo "<div id='cancel_job_changes_button' style='display:none'>
-                      <button type='button' class='btn btn-secondary me-2'
-                             onclick='taskjobs.edit(\"" . $this->getBaseUrlFor('fi.job.edit') . "\", $id)'>" .
-                             __('Cancel modifications', 'glpiinventory') . "</button>
-                   </div>";
 
             echo Html::submit(__('Update'), ['name' => 'update', 'class' => 'btn btn-primary me-2']);
             echo "</td>";


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

Hello guys,
I believe that https://github.com/glpi-project/glpi-inventory-plugin/pull/635 introduced an alignment issue on 'Cancel modifications' button.

## Screenshots (if appropriate):

Before this PR:

![image](https://github.com/user-attachments/assets/960179cf-56f8-460e-b264-f8fe511e992d)

After this PR:

<img width="354" alt="image" src="https://github.com/user-attachments/assets/30609e87-5deb-4b71-8d4f-91cae93a1de9" />
