### PR TITLE
Fix wrong name displayed in taskjob.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix implementation of link in task log
+- Fix wrong name displayed in taskjob state page
 
 ## [1.5.0] - 2025-02-25
 

--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -337,27 +337,36 @@ function agents_chart(chart_id) {
             });
 
             // display name
-            var names = d3.select(this).selectAll('a.name').data([d])
+            var names = d3.select(this).selectAll('a.name').data([d]);
+
+            // Gérer les nouveaux éléments (enter)
             var spans = names.enter().append('span');
             spans.append('i')
-               .attr('class', 'fa-solid fa-thumbtack');
+            .attr('class', 'fa-solid fa-thumbtack');
             spans.append('a')
-               .attr('class', 'name')
-               .on('click', function(d) {
-                  var args = {
-                     chart_id: chart_id,
-                     data: d
-                  };
-                  if ( !agent_is_pinned(args) ) {
-                     pin_agent(args);
-                  } else {
-                     unpin_agent(args);
-                  }
-               })
-               .attr('href', 'javascript:void(0)')
-               .text(taskjobs.data.agents[d[0]]);
+            .attr('class', 'name')
+            .attr('href', 'javascript:void(0)');
 
+            // Gérer les éléments qui sortent (exit)
             names.exit().remove();
+
+            // Mettre à jour TOUS les éléments (nouveaux + existants)
+            d3.select(this).selectAll('a.name')
+            .text(function(d) { 
+                // Afficher le nom de l'agent plutôt que juste l'état
+                return taskjobs.data.agents[d[0]]; 
+            })
+            .on('click', function(d) {
+                var args = {
+                    chart_id: chart_id,
+                    data: d
+                };
+                if (!agent_is_pinned(args)) {
+                    pin_agent(args);
+                } else {
+                    unpin_agent(args);
+                }
+            });
 
             //add date
             var dates = d3.select(this).selectAll('span.date').data([d]);
@@ -434,17 +443,11 @@ function agents_chart(chart_id) {
                         "</th></tr>"
                      );
                       $.each(run.logs, function(log_index, log) {
-                        var logComment = log['log.comment'];
-                        var parts = logComment.split(/(<a.*?>|<\/a>)/);
-                        
-                        var logComment = __(parts[0], 'glpiinventory');
-                        logComment += parts.slice(1).join(' ');
-
                         rows.push(
                            "<tr class='run log" + ((taskjob_state !== null) ? ' run_' + taskjob_state : '' ) + "'>" +
                            "<td>" + log['log.date'] +"</td>"+
                            "<td>" + taskjobs.logstatuses_names[log['log.state']] +"</td>"+
-                           "<td class='comment'>" + logComment +"</td>"+
+                           "<td class='comment'>" + __(log['log.comment'], 'glpiinventory') +"</td>"+
                            "</tr>"
                         );
                       });

--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -339,7 +339,6 @@ function agents_chart(chart_id) {
             // display name
             var names = d3.select(this).selectAll('a.name').data([d]);
 
-            // Gérer les nouveaux éléments (enter)
             var spans = names.enter().append('span');
             spans.append('i')
             .attr('class', 'fa-solid fa-thumbtack');
@@ -347,13 +346,12 @@ function agents_chart(chart_id) {
             .attr('class', 'name')
             .attr('href', 'javascript:void(0)');
 
-            // Gérer les éléments qui sortent (exit)
             names.exit().remove();
 
-            // Mettre à jour TOUS les éléments (nouveaux + existants)
+            // Update all elements (olds + news)
             d3.select(this).selectAll('a.name')
             .text(function(d) { 
-                // Afficher le nom de l'agent plutôt que juste l'état
+                // Update name displayed
                 return taskjobs.data.agents[d[0]]; 
             })
             .on('click', function(d) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37243
- Here is a brief description of what this PR does
When the user wishes to display several results with different status (cancelled, success, error, ...), the names of all the elements are not redefined, only the new ones.

## Screenshots (if appropriate):
**Before**
![image](https://github.com/user-attachments/assets/4c3780cb-548b-4f30-8018-8d3bdf01ee71)

**After**
![image](https://github.com/user-attachments/assets/270aa8da-9cc9-4749-bb68-f22c01cc44d6)

