### PR TITLE
Fix wrong item linked to the taskjobs

### DIFF
--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -319,6 +319,13 @@ function agents_chart(chart_id) {
             .attr('class', 'fa fa-link link')
             .attr('href', d[1][0].link);
 
+            // Update - Update all elements (new + existing)
+            d3.select(this).selectAll('a.link')
+                .attr('href', function(d) {
+                    return d[1][0].link;
+                })
+                .attr('class', 'fa fa-link link');
+
             // add a checkbox for bulk actions
             var checkb = d3.select(this).selectAll('input').data([d]);
             checkb.enter().append('input')
@@ -350,9 +357,9 @@ function agents_chart(chart_id) {
 
             // Update all elements (olds + news)
             d3.select(this).selectAll('a.name')
-            .text(function(d) { 
+            .text(function(d) {
                 // Update name displayed
-                return taskjobs.data.agents[d[0]]; 
+                return taskjobs.data.agents[d[0]];
             })
             .on('click', function(d) {
                 var args = {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37243
- Here is a brief description of what this PR does

When clicking on the icon to open the computer page linked to the selected taskjob, the redirection link is wrong. For example, here : Instead of opening the page for the computer linked to agent 2, it opens the page for the computer linked to agent 7.

## Screenshots (if appropriate):

![Screenshot from 2025-04-24 09-50-00](https://github.com/user-attachments/assets/cefd6248-49c3-40f0-8083-f2a571651c46)

