### PR TITLE
Fix target list if table doesn't have is_active field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix `getFilePart` for `deploy` module
-- Fix `Target` drop-down list to filter on active target only
+- Fix `Target` drop-down list to filter on active target only (if is_active fields exist) #679 & #682
 
 ## [1.5.2] - 2025-04-30
 

--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -478,7 +478,10 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
                 $condition = ['id' => $filter_id];
             }
         }
-        $condition['is_active'] = 1;
+        $itemtype_class = new $itemtype();
+        if ($DB->fieldExists($itemtype_class->getTable(), 'is_active')) {
+            $condition['is_active'] = 1;
+        }
 
        /**
         * get Itemtype choices dropdown

--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -478,8 +478,7 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
                 $condition = ['id' => $filter_id];
             }
         }
-        $itemtype_class = new $itemtype();
-        if ($DB->fieldExists($itemtype_class->getTable(), 'is_active')) {
+        if ($DB->fieldExists($itemtype::getTable(), 'is_active')) {
             $condition['is_active'] = 1;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37660
- Here is a brief description of what this PR does
Some module methods have targets that don't have the is_active field in the base, preventing the list from loading.

## Screenshots (if appropriate):
**Before**
![image](https://github.com/user-attachments/assets/e20edec8-3493-4b42-aa99-e0be61559e96)

**After**
![image](https://github.com/user-attachments/assets/adad1a5a-33d6-402b-bafa-970f58489ce9)


