### PR TITLE
Fix undefined array key; closes #690

### DIFF
--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -857,7 +857,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                 $agent_ids = $saved_agent_ids;
                 $item_type = key($target);
                 $item_id   = current($target);
-                $job_id    = $result['job']['id'];
+                $job_id    = $result['job']['jobid'];
                 // Filter out agents that are already running the targets.
                 $jobstates_running = $jobstate->find(
                     ['itemtype' => $item_type,

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -857,6 +857,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                 $agent_ids = $saved_agent_ids;
                 $item_type = key($target);
                 $item_id   = current($target);
+                var_dump($result['job']);
                 $job_id    = $result['job']['jobid'];
                 // Filter out agents that are already running the targets.
                 $jobstates_running = $jobstate->find(

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -750,7 +750,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                 'task.id',
                 'task.name',
                 'task.reprepare_if_successful',
-                'job.id AS jobid',
+                'job.id',
                 'job.name AS jobname',
                 'job.method',
                 'job.targets',
@@ -858,7 +858,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                 $item_type = key($target);
                 $item_id   = current($target);
                 var_dump($result['job']);
-                $job_id    = $result['job']['jobid'];
+                $job_id    = $result['job']['id'];
                 // Filter out agents that are already running the targets.
                 $jobstates_running = $jobstate->find(
                     ['itemtype' => $item_type,

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -750,7 +750,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                 'task.id',
                 'task.name',
                 'task.reprepare_if_successful',
-                'job.id',
+                'job.id AS jobid',
                 'job.name AS jobname',
                 'job.method',
                 'job.targets',
@@ -801,6 +801,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
             ]
         ]);
         $results = PluginGlpiinventoryToolbox::fetchAssocByTableIterator($iterator);
+        var_dump($results);
 
         // Fetch a list of actors to be prepared. We may have the same actors for each job so this
         // part can speed up the process.
@@ -857,8 +858,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                 $agent_ids = $saved_agent_ids;
                 $item_type = key($target);
                 $item_id   = current($target);
-                var_dump($result['job']);
-                $job_id    = $result['job']['id'];
+                $job_id    = $result['job']['jobid'];
                 // Filter out agents that are already running the targets.
                 $jobstates_running = $jobstate->find(
                     ['itemtype' => $item_type,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #690

Another attempt.

From what I understand, `fetchAssocByTableIterator` associates row data in the format `array[table][field]`.
Therefore, `'job.id AS jobid'` should be structured as `array['job']['jobid']`.


## Screenshots (if appropriate):

