### PR TITLE
Prevent ipv6

### DIFF
--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -513,6 +513,7 @@ class PluginGlpiinventoryNetworkinventory extends PluginGlpiinventoryCommunicati
                 'WHERE' => [
                     $itemtype::getTable() . '.is_deleted' => 0,
                     'snmpcredentials_id' => ['!=', '0'],
+                    'glpi_ipaddresses.version' => 4,
                     new \QueryExpression(
                         'inet_aton(' . $DB->quoteName('glpi_ipaddresses.name') . ') BETWEEN ' .
                         'inet_aton(' . $DB->quote($pfIPRange->fields['ip_start']) . ') AND inet_aton(' .


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The `getDevicesOfIPRange` list retrieves all assets whose IP matches the `RangeIP` defined in the task.

However, it is not limited to IPv4 addresses — IPv6 addresses are also checked, which can cause an SQL error in the case of a localhost IPv6 address.

Like `::1`

```shell
[2025-09-05 08:15:31] glpisqllog.WARNING: DBmysql::doQuery() in D:\wamp\www\glpi\src\DBmysql.php line 438
  *** MySQL query warnings:
  SQL: SELECT `glpi_printers`.`id` AS `gID`, `glpi_printers`.`name` AS `gNAME`, `glpi_ipaddresses`.`name` AS `gnifaddr`, `snmpcredentials_id` FROM `glpi_printers` LEFT JOIN `glpi_networkports` ON (`glpi_networkports`.`items_id` = `glpi_printers`.`id` AND `glpi_networkports`.`itemtype` = 'Printer') LEFT JOIN `glpi_networknames` ON (`glpi_networknames`.`items_id` = `glpi_networkports`.`id` AND `glpi_networknames`.`itemtype` = 'NetworkPort') LEFT JOIN `glpi_ipaddresses` ON (`glpi_ipaddresses`.`items_id` = `glpi_networknames`.`id` AND `glpi_ipaddresses`.`itemtype` = 'NetworkName') WHERE `glpi_printers`.`is_deleted` = '0' AND `snmpcredentials_id` != '0' AND inet_aton(`glpi_ipaddresses`.`name`) BETWEEN inet_aton('adresseipstart1') AND inet_aton('ipadresseipend1') GROUP BY `gID`
  Warnings: 
1411: Incorrect string value: '`glpi`.`glpi_ipaddresses`.`name`' for function inet_aton
  Backtrace :
  src\DBmysqlIterator.php:112                        DBmysql->doQuery()
  src\DBmysql.php:1105                               DBmysqlIterator->execute()
  ...lpiinventory\inc\networkinventory.class.php:532 DBmysql->request()
  plugins\glpiinventory\inc\taskview.class.php:848   PluginGlpiinventoryNetworkinventory->getDevicesOfIPRange()
  plugins\glpiinventory\inc\task.class.php:635       PluginGlpiinventoryTaskView->prepareTaskjobs()
  src\CronTask.php:1027                              PluginGlpiinventoryTask::cronTaskscheduler()
  front\cron.php:87                                  CronTask::launch()
```

Partially fix https://github.com/glpi-project/glpi-inventory-plugin/issues/737

## Screenshots (if appropriate):

