### PR TITLE
Fix: check instanceof CommonDBTM

### DIFF
--- a/inc/collect.class.php
+++ b/inc/collect.class.php
@@ -67,8 +67,7 @@ class PluginGlpiinventoryCollect extends CommonDBTM
      */
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        /** @var CommonDBTM $item */
-        if ($item->fields['id'] > 0) {
+        if ($item instanceof CommonDBTM && $item->fields['id'] > 0) {
             $index = self::getNumberOfCollectsForAComputer($item->fields['id']);
             $nb    = 0;
             if ($index > 0) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A

Avoid this kind of warning: 

```
glpi.WARNING:   *** Warning: Undefined property: PluginPdfComputer::$fields at collect.class.php line 71
  Backtrace :
  ./plugins/glpiinventory/inc/collect.class.php:71   
  ./src/CommonGLPI.php:357                           PluginGlpiinventoryCollect->getTabNameForItem()
  ./plugins/pdf/inc/common.class.php:54              CommonGLPI->addStandardTab()
  ./plugins/pdf/inc/common.class.php:92              PluginPdfCommon->addStandardTab()
  ./plugins/pdf/inc/computer.class.php:44            PluginPdfCommon->defineAllTabsPDF()
  ./plugins/pdf/inc/preference.class.php:95          PluginPdfComputer->defineAllTabsPDF()
  ./plugins/pdf/inc/common.class.php:274             PluginPdfPreference->menu()
  ./src/CommonGLPI.php:694                           PluginPdfCommon::displayTabContentForItem()
  ./ajax/common.tabs.php:108                         CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()

glpi.WARNING:   *** Warning: Trying to access array offset on null at collect.class.php line 71
  Backtrace :
  ./plugins/glpiinventory/inc/collect.class.php:71   
  ./src/CommonGLPI.php:357                           PluginGlpiinventoryCollect->getTabNameForItem()
  ./plugins/pdf/inc/common.class.php:54              CommonGLPI->addStandardTab()
  ./plugins/pdf/inc/common.class.php:92              PluginPdfCommon->addStandardTab()
  ./plugins/pdf/inc/computer.class.php:44            PluginPdfCommon->defineAllTabsPDF()
  ./plugins/pdf/inc/preference.class.php:95          PluginPdfComputer->defineAllTabsPDF()
  ./plugins/pdf/inc/common.class.php:274             PluginPdfPreference->menu()
  ./src/CommonGLPI.php:694                           PluginPdfCommon::displayTabContentForItem()
  ./ajax/common.tabs.php:108                         CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```

## Screenshots (if appropriate):

