### PR TITLE
Fix(Core): fix URL computation for ressources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+- Fix URL for ressource (ajax/ front/ pics/ etc .. )
+
 ## [1.6.3] - 2025-11-25
 
 ### Fixed

--- a/inc/commonview.class.php
+++ b/inc/commonview.class.php
@@ -74,7 +74,7 @@ class PluginGlpiinventoryCommonView extends CommonDBTM
         global $CFG_GLPI;
         parent::__construct();
 
-        $fi_path = sprintf('%s/plugins/glpiinventory', $CFG_GLPI['url_base']);
+        $fi_path = Html::getPrefixedUrl("/plugins/glpiinventory");
 
         $this->base_urls = [
             'fi.base'   => $fi_path,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It (should) fixes #825 

Do not rely on `$CFG_GLPI['url_base']`; instead, prefer `$CFG_GLPI['root_doc']`, which is used by `Html::getPrefixedUrl()`.


## Screenshots (if appropriate):

