### PR TITLE
Fix(Deploy): Remove the 'Cancel Job' button for 'self-deploy'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## UNRELEASED
 
 - Fix PHP exception on empty task job agent dropdown
+- Remove the `Cancel Job` button for 'self-deploy' users, as they do not have the necessary permissions.
 
 ## [1.6.5] - 2026-01-08
 

--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -1494,15 +1494,6 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
                               <i class='fa fa-bolt'></i></a>";
                             }
 
-                            // if job has not started, user can cancel it
-                            if ($package_info['last_taskjobstate']['state'] == "agents_prepared") {
-                                echo "<a class='cancel btn'
-                                 href='#'
-                                 title='" . __("Cancel job", 'glpiinventory') . "'
-                                 id='cancel_run_$taskjob_id'>
-                              <i class='fa fa-stop'></i></a>";
-                            }
-
                             // permits to "soft" refresh
                             echo "<a href='#'
                               title='" . __("refresh job", 'glpiinventory') . "'


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

same as https://github.com/glpi-project/glpi-inventory-plugin/pull/892 but for GLPI 11

- It fixes !41743

Remove the `Cancel Job` button for 'self-deploy' users, as they do not have the necessary permissions.

<img width="668" height="306" alt="image" src="https://github.com/user-attachments/assets/bfc4d26b-3e35-4874-b79d-c54d6b967fc7" />

Additionally, this action terminates the entire task, not just the associated job (historical change made by DD).

## Screenshots (if appropriate):
