### PR TITLE
1.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED]
+## [1.5.7] - 2026-02-18
 
 - Remove the `Cancel Job` button for 'self-deploy' users, as they do not have the necessary permissions.
 

--- a/glpiinventory.xml
+++ b/glpiinventory.xml
@@ -92,6 +92,11 @@
    </authors>
    <versions>
       <version>
+         <num>1.5.7</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.5.7/glpi-glpiinventory-1.5.7.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.5.6</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.5.6/glpi-glpiinventory-1.5.6.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -33,7 +33,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define("PLUGIN_GLPIINVENTORY_VERSION", "1.5.6");
+define("PLUGIN_GLPIINVENTORY_VERSION", "1.5.7");
 // Minimal GLPI version, inclusive
 define('PLUGIN_GLPI_INVENTORY_GLPI_MIN_VERSION', '10.0.11');
 // Maximum GLPI version, exclusive


### PR DESCRIPTION
## [1.5.7] - 2026-02-18

- Remove the `Cancel Job` button for 'self-deploy' users, as they do not have the necessary permissions.