### PR TITLE
Update communicationnetworkinventory.class.php

### DIFF
--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -159,8 +159,8 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                                 . ' [[' . $item::class . '::' . $item->getID() . ']]';
                             $this->addtaskjoblog();
                             Plugin::doHookFunction('glpiinventory_post_network_discovery', [
-								'item'     => $item,
-								'raw_data' => $a_CONTENT,
+                                'item'     => $item,
+                                'raw_data' => $a_CONTENT,
 							]);
                         }
                         $response = ['response' => ['RESPONSE' => 'SEND']];

--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -158,7 +158,7 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                                 = '[==detail==] ' . $what . ' ' . $item->getTypeName()
                                 . ' [[' . $item::class . '::' . $item->getID() . ']]';
                             $this->addtaskjoblog();
-							Plugin::doHookFunction('glpiinventory_post_network_discovery', [
+                            Plugin::doHookFunction('glpiinventory_post_network_discovery', [
 								'item'     => $item,
 								'raw_data' => $a_CONTENT,
 							]);

--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -158,6 +158,10 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                                 = '[==detail==] ' . $what . ' ' . $item->getTypeName()
                                 . ' [[' . $item::class . '::' . $item->getID() . ']]';
                             $this->addtaskjoblog();
+							Plugin::doHookFunction('glpiinventory_post_network_discovery', [
+								'item'     => $item,
+								'raw_data' => $a_CONTENT,
+							]);
                         }
                         $response = ['response' => ['RESPONSE' => 'SEND']];
                     }

--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -161,7 +161,7 @@ class PluginGlpiinventoryCommunicationNetworkDiscovery
                             Plugin::doHookFunction('glpiinventory_post_network_discovery', [
                                 'item'     => $item,
                                 'raw_data' => $a_CONTENT,
-							]);
+                            ]);
                         }
                         $response = ['response' => ['RESPONSE' => 'SEND']];
                     }

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -175,7 +175,7 @@ class PluginGlpiinventoryCommunicationNetworkInventory
                         . ' [[' . $item::class . '::' . $item->fields['id'] . ']]';
                     $this->addtaskjoblog();
 					
-					Plugin::doHookFunction('glpiinventory_post_network_inventory', [
+                    Plugin::doHookFunction('glpiinventory_post_network_inventory', [
                           'item'     => $item,
                           'raw_data' => $a_CONTENT,
                       ]);

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -174,7 +174,6 @@ class PluginGlpiinventoryCommunicationNetworkInventory
                         = '[==detail==] ==updatetheitem== ' . $item->getTypeName()
                         . ' [[' . $item::class . '::' . $item->fields['id'] . ']]';
                     $this->addtaskjoblog();
-					
                     Plugin::doHookFunction('glpiinventory_post_network_inventory', [
                           'item'     => $item,
                           'raw_data' => $a_CONTENT,

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -175,9 +175,9 @@ class PluginGlpiinventoryCommunicationNetworkInventory
                         . ' [[' . $item::class . '::' . $item->fields['id'] . ']]';
                     $this->addtaskjoblog();
                     Plugin::doHookFunction('glpiinventory_post_network_inventory', [
-                          'item'     => $item,
-                          'raw_data' => $a_CONTENT,
-                      ]);
+                        'item'     => $item,
+                        'raw_data' => $a_CONTENT,
+                    ]);
                 }
                 $response = ['response' => ['RESPONSE' => 'SEND']];
             }

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -169,18 +169,18 @@ class PluginGlpiinventoryCommunicationNetworkInventory
                     $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '==importdenied== ' . implode(", ", $a_text);
                     $this->addtaskjoblog();
                 } else {
-                      $item = $inventory->getMainAsset()->getItem();
-                      $_SESSION['plugin_glpiinventory_taskjoblog']['comment']
-                          = '[==detail==] ==updatetheitem== ' . $item->getTypeName()
-                          . ' [[' . $item::class . '::' . $item->fields['id'] . ']]';
-                      $this->addtaskjoblog();
-                
-                      Plugin::doHookFunction('glpiinventory_post_network_inventory', [
+                    $item = $inventory->getMainAsset()->getItem();
+                    $_SESSION['plugin_glpiinventory_taskjoblog']['comment']
+                        = '[==detail==] ==updatetheitem== ' . $item->getTypeName()
+                        . ' [[' . $item::class . '::' . $item->fields['id'] . ']]';
+                    $this->addtaskjoblog();
+					
+					Plugin::doHookFunction('glpiinventory_post_network_inventory', [
                           'item'     => $item,
                           'raw_data' => $a_CONTENT,
                       ]);
-                  }
-                  $response = ['response' => ['RESPONSE' => 'SEND']];
+                }
+                $response = ['response' => ['RESPONSE' => 'SEND']];
             }
         }
 

--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -169,13 +169,18 @@ class PluginGlpiinventoryCommunicationNetworkInventory
                     $_SESSION['plugin_glpiinventory_taskjoblog']['comment'] = '==importdenied== ' . implode(", ", $a_text);
                     $this->addtaskjoblog();
                 } else {
-                    $item = $inventory->getMainAsset()->getItem();
-                    $_SESSION['plugin_glpiinventory_taskjoblog']['comment']
-                        = '[==detail==] ==updatetheitem== ' . $item->getTypeName()
-                        . ' [[' . $item::class . '::' . $item->fields['id'] . ']]';
-                    $this->addtaskjoblog();
-                }
-                $response = ['response' => ['RESPONSE' => 'SEND']];
+                      $item = $inventory->getMainAsset()->getItem();
+                      $_SESSION['plugin_glpiinventory_taskjoblog']['comment']
+                          = '[==detail==] ==updatetheitem== ' . $item->getTypeName()
+                          . ' [[' . $item::class . '::' . $item->fields['id'] . ']]';
+                      $this->addtaskjoblog();
+                
+                      Plugin::doHookFunction('glpiinventory_post_network_inventory', [
+                          'item'     => $item,
+                          'raw_data' => $a_CONTENT,
+                      ]);
+                  }
+                  $response = ['response' => ['RESPONSE' => 'SEND']];
             }
         }
 


### PR DESCRIPTION
  Checklist before requesting a review

  - I have performed a self-review of my code.
  - I have added tests (when available) that prove my fix is effective or that my feature works.
  - I have updated the CHANGELOG with a short functional description of the fix or new feature.
  - This change requires a documentation update.

  Description

  - It fixes # (not applicable — new feature)
  - Adds a glpiinventory_post_network_inventory hook that fires in
  PluginGlpiinventoryCommunicationNetworkInventory::import() after doInventory() completes successfully, providing
  third-party plugins with both the persisted asset item and the full raw SNMP inventory data.

  Problem:
  There is currently no hook in the glpiinventory code path that fires after the network device has been written to the
  database. The core GLPI NETWORK_INVENTORY hook fires before doInventory(), so newly discovered devices may not exist
  in the DB yet. The core GLPI POST_INVENTORY hook does not fire on the glpiinventory path at all.

  This makes it impossible for third-party plugins to reliably post-process network inventory data (e.g. topology
  linking, module asset creation, impact relation building) when devices are managed via glpiinventory agents.

  Solution:
  One line added in the else branch (inventory accepted, not refused) after doInventory() succeeds:

  Plugin::doHookFunction('glpiinventory_post_network_inventory', [
      'item'     => $item,      // asset already persisted in DB
      'raw_data' => $a_CONTENT, // full SNMP data (network_ports, network_components, …)
  ]);

  Third-party plugins register via:
  $PLUGIN_HOOKS['glpiinventory_post_network_inventory']['myplugin']
      = 'plugin_myplugin_callback';

  The change is purely additive — no existing behavior is modified.
