### PR TITLE
Add index on itemtype and items_id in taskjobstates

### DIFF
--- a/install/mysql/plugin_glpiinventory-empty.sql
+++ b/install/mysql/plugin_glpiinventory-empty.sql
@@ -153,7 +153,8 @@ CREATE TABLE `glpi_plugin_glpiinventory_taskjobstates` (
   PRIMARY KEY (`id`),
   KEY `plugin_glpiinventory_taskjobs_id` (`plugin_glpiinventory_taskjobs_id`),
   KEY `agents_id` (`agents_id`),
-  KEY `uniqid` (`uniqid`,`state`)
+  KEY `uniqid` (`uniqid`,`state`),
+  KEY `item` (`itemtype`, `items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/install/update.php
+++ b/install/update.php
@@ -1091,6 +1091,12 @@ function addTaskJobLogIndex(Migration $migration): Migration
         'item'
     );
 
+    $migration->addKey(
+        "glpi_plugin_glpiinventory_taskjobstates",
+        ['itemtype', 'items_id'],
+        'item'
+    );
+
     return $migration;
 }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !42703
- Here is a brief description of what this PR does
Add an index (itemtype, items_id) to the glpi_plugin_glpiinventory_taskjobstates table.

This table, which can contain millions of rows, is scanned by Migration::renameItemtype() during the update to GLPI 11. Without an index on itemtype, every UPDATE ... WHERE itemtype = ‘...’ causes a full table scan, which slows down the migration on large instances. 

## Screenshots (if appropriate):
