### PR TITLE
Fix sql error group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix module / exception handling during updates from the agent or general settings.
 - Fix display of rights for deploy on demand
+- Fix MySQL query error: Unknown column 'groups_id'
 
 ## [1.6.8] - UNRELEASED
 

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -1044,9 +1044,10 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                     }
 
                     //find computers directly associated with this group
-                    $computer_from_group = $computer->find(['groups_id' => $itemid]);
+                    $group_item = new Group_Item();
+                    $computer_from_group = $group_item->getItemsAssociatedTo(Group::class, $itemid);
                     foreach ($computer_from_group as $computer_entry) {
-                        $computers[$computer_entry['id']] = 1;
+                        $computers[$computer_entry->fields['id']] = 1;
                     }
                     break;
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #923 

Fix

```
[2026-03-20 13:52:04] glpi.ERROR: *** Caught RuntimeException: MySQL query error: Unknown column 'groups_id' in 'where clause' (1054) in SQL query "SELECT * FROM glpi_computers WHERE groups_id = '123'".
Backtrace :
.\src\DBmysql.php:416
.\src\DBmysqlIterator.php:129 DBmysql->doQuery()
.\src\DBmysql.php:1088 DBmysqlIterator->execute()
.\src\CommonDBTM.php:632 DBmysql->request()
...ugins\glpiinventory\inc\taskview.class.php:1040 CommonDBTM->find()
.\plugins\glpiinventory\inc\taskview.class.php:831 PluginGlpiinventoryTaskView->getAgentsFromActors()
.\plugins\glpiinventory\inc\task.class.php:642 PluginGlpiinventoryTaskView->prepareTaskjobs()
.\src\CronTask.php:887 PluginGlpiinventoryTask::cronTaskscheduler()
.\front\cron.php:136 CronTask::launch()
``` 

## Screenshots (if appropriate):
