### PR TITLE
Fix pics file path warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix module / exception handling during updates from the agent or general settings.
 - Fix display of rights for deploy on demand
 - Fix MySQL query error: Unknown column 'groups_id'
+- Fix warning : `file pics/extensions/... is not within the allowed path(s)`
 
 ## [1.6.8] - UNRELEASED
 

--- a/inc/deployfile.class.php
+++ b/inc/deployfile.class.php
@@ -163,7 +163,7 @@ class PluginGlpiinventoryDeployFile extends PluginGlpiinventoryDeployPackageItem
             = $data['associatedFiles'][$sha512]['p2p-retention-duration'];
 
             // start new line
-            $pics_path = $CFG_GLPI['root_doc'] . "/plugins/glpiinventory/pics/";
+            $pics_path = $CFG_GLPI['root_doc'] . "/plugins/glpiinventory/public/pics/";
             echo Search::showNewLine(Search::HTML_OUTPUT, (bool) ($i % 2));
             if ($canedit) {
                 echo "<td class='control'>";


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43855
- Here is a brief description of what this PR does

The “pics” directory has been moved from glpiinventory/pics to glpiinventory/public/pics, which is causing the following warning : 
```
  PHP Warning (2): file_exists(): open_basedir restriction in effect.
  File(/plugins/glpiinventory/pics/extensions/application__x-msi; charset=binary.png)
  is not within the allowed path(s) in deployfile.class.php à la ligne 176
  ```

## Screenshots (if appropriate):
