### PR TITLE
Fix - Use filesystem path for file_exists() in DeployFile display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix display of rights for deploy on demand
 - Fix MySQL query error: Unknown column 'groups_id'
 - Fix warning : `file pics/extensions/... is not within the allowed path(s)`
+- Fix warning : `open_basedir restriction in effect`
 
 ## [1.6.8] - UNRELEASED
 

--- a/inc/deployfile.class.php
+++ b/inc/deployfile.class.php
@@ -163,7 +163,8 @@ class PluginGlpiinventoryDeployFile extends PluginGlpiinventoryDeployPackageItem
             = $data['associatedFiles'][$sha512]['p2p-retention-duration'];
 
             // start new line
-            $pics_path = $CFG_GLPI['root_doc'] . "/plugins/glpiinventory/public/pics/";
+            $pics_url  = $CFG_GLPI['root_doc'] . "/plugins/glpiinventory/public/pics/";
+            $pics_path = Plugin::getPhpDir('glpiinventory') . "/public/pics/";
             echo Search::showNewLine(Search::HTML_OUTPUT, (bool) ($i % 2));
             if ($canedit) {
                 echo "<td class='control'>";
@@ -175,9 +176,9 @@ class PluginGlpiinventoryDeployFile extends PluginGlpiinventoryDeployPackageItem
                 !empty($file_mimetype)
                  && file_exists($pics_path . "extensions/$file_mimetype.png")
             ) {
-                echo "<img src='" . $pics_path . "extensions/$file_mimetype.png' />";
+                echo "<img src='" . $pics_url . "extensions/$file_mimetype.png' />";
             } else {
-                echo "<img src='" . $pics_path . "extensions/documents.png' />";
+                echo "<img src='" . $pics_url . "extensions/documents.png' />";
             }
 
             //filename


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44253
- Here is a brief description of what this PR does

`file_exists()` was called with a URL path built from `$CFG_GLPI['root_doc']`, causing a PHP warning on hosts with `open_basedir` restrictions.

```php
PHP Warning (2):file_exists(): open_basedir restriction in effect. File(/plugins/glpiinventory/public/pics/extensions/application__x-zip-compressed.png) is not within the allowed path(s): (/tmp/:/home/...) at deployfile.class.php line 176 in ./marketplace/glpiinventory/inc/deployfile.class.php at line 176
```

Split the variable into:
- `$pics_path` — absolute filesystem path via `Plugin::getPhpDir()`, used for `file_exists()`
- `$pics_url` — URL path via `$CFG_GLPI['root_doc']`, used for `<img src>`

Fixes the warning introduced after #948 moved the pics folder to `public/pics/`.
