### PR TITLE
Fix(ESC): prevent uniqid collision in ESX taskjobstate creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix MySQL query error: Unknown column 'groups_id'
 - Fix warning : `file pics/extensions/... is not within the allowed path(s)`
 - Fix warning : `open_basedir restriction in effect`
+- Fix ESX job status incorrectly showing all hosts as 'In Error' when only one host fails and the others complete successfully.
 
 ## [1.6.8] - UNRELEASED
 

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -949,7 +949,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                                 'items_id'                           => $item_id,
                                 'plugin_glpiinventory_taskjobs_id' => $job_id,
                                 'agents_id'   => $agent_id,
-                                'uniqid'                             => uniqid(),
+                                'uniqid'                             => bin2hex(random_bytes(16)),
                             ]
                         );
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Fixes: #647 

Use `bin2hex(random_bytes(16))` to generates 128 bits of cryptographically secure entropy, making collisions practically impossible.
 In contrast,` uniqid()` relies primarily on the system clock with microsecond precision and can produce duplicate values when invoked repeatedly in rapid succession.

_This is the only factor that could cause this error._

## Screenshots (if appropriate):
