### PR TITLE
fix (import) produce a valid CSV when exporting task execution results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
-- Fix export csv
+- Fix task execution results CSV export
 
 ## [1.6.8] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+- Fix export csv
+
 ## [1.6.8] - 2026-06-24
 
 - Fix module / exception handling during updates from the agent or general settings.

--- a/inc/credential.class.php
+++ b/inc/credential.class.php
@@ -283,7 +283,7 @@ class PluginGlpiinventoryCredential extends CommonDropdown
     public static function getLabelByItemtype($credential_itemtype)
     {
         $credentialtypes = self::findItemtypeType($credential_itemtype);
-        if (!empty($credentialtypes)) {
+        if ($credentialtypes !== []) {
             return $credentialtypes['name'];
         }
         return false;
@@ -427,7 +427,7 @@ class PluginGlpiinventoryCredential extends CommonDropdown
     public static function hasAlLeastOneType()
     {
         $types = self::getCredentialsItemTypes();
-        return (!empty($types));
+        return ($types !== []);
     }
 
 

--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -472,7 +472,7 @@ class PluginGlpiinventoryTaskjobView extends PluginGlpiinventoryCommonView
                 }
             }
 
-            if (empty($filter_id)) {
+            if ($filter_id === []) {
                 // No available agents/computers: show empty dropdown safely
                 $this->showDropdownFromArray(
                     $title,

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -551,6 +551,8 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
      */
     public function csvExport($params = [])
     {
+        global $CFG_GLPI;
+
         $default_params = [
             'agent_state_types' => [],
         ];
@@ -593,14 +595,15 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
         // clean old temporary variables
         unset($task, $job, $target, $agent);
 
-        $spread = $this->buildSpreadsheet($data, $includeoldjobs);
+        define('SEP', $CFG_GLPI['csv_delimiter']); // @phpstan-ignore theCodingMachineSafe.function
+        define('NL', "\r\n"); // @phpstan-ignore theCodingMachineSafe.function
 
-        $writer = new CsvWriter($spread);
+        $writer = new CsvWriter($this->buildSpreadsheet($data, $includeoldjobs));
         $writer
-            ->setDelimiter($_SESSION['glpicsv_delimiter'] ?? ';')
+            ->setDelimiter(SEP)
             ->setEnclosure('"')
             ->setUseBOM(true)
-            ->setLineEnding("\r\n")
+            ->setLineEnding(NL)
             ->setSheetIndex(0);
         $writer->save('php://output');
 
@@ -662,11 +665,13 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                         }
 
                         foreach ($target['agents'] as $agent_id => $agent) {
-                            $agent_obj->getFromDB($agent_id);
-                            $agent_name = $agent_obj->getName();
+                            $agent_name = '';
                             $computer_name = '';
-                            if (isset($agent_obj->fields['items_id']) && $computer->getFromDB($agent_obj->fields['items_id'])) {
-                                $computer_name = $computer->getName();
+                            if ($agent_obj->getFromDB($agent_id)) {
+                                $agent_name = $agent_obj->getName();
+                                if (isset($agent_obj->fields['items_id']) && $computer->getFromDB($agent_obj->fields['items_id'])) {
+                                    $computer_name = $computer->getName();
+                                }
                             }
 
                             if (empty($agent)) {

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -34,6 +34,10 @@
 use Glpi\DBAL\QueryExpression;
 use Safe\DateTime;
 
+use Glpi\Search\Output\SpreadsheetValueBinder;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Csv as CsvWriter;
+
 use function Safe\json_decode;
 use function Safe\json_encode;
 
@@ -548,8 +552,6 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
      */
     public function csvExport($params = [])
     {
-        global $CFG_GLPI;
-
         $default_params = [
             'agent_state_types' => [],
         ];
@@ -592,10 +594,35 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
         // clean old temporary variables
         unset($task, $job, $target, $agent);
 
-        $delimiter = $CFG_GLPI['csv_delimiter'];
-        $out       = fopen('php://output', 'w');
+        $spread = $this->buildSpreadsheet($data, $includeoldjobs);
 
-        fputcsv($out, [
+        $writer = new CsvWriter($spread);
+        $writer
+            ->setDelimiter($_SESSION['glpicsv_delimiter'] ?? ';')
+            ->setEnclosure('"')
+            ->setUseBOM(true)
+            ->setLineEnding("\r\n")
+            ->setSheetIndex(0);
+        $writer->save('php://output');
+
+        // force exit to prevent further display
+        exit; //@phpstan-ignore-line (whole method needs to be refactored)
+    }
+
+
+    /**
+     * @param array $data
+     * @param int $includeoldjobs
+     * @return Spreadsheet
+     */
+    public function buildSpreadsheet(array $data, int $includeoldjobs): Spreadsheet
+    {
+        $spread = new Spreadsheet();
+        // Prevent values starting with "=" from being interpreted as formulas (excel)
+        $spread->setValueBinder(new SpreadsheetValueBinder());
+        $sheet = $spread->getActiveSheet();
+
+        $headers = [
             'Task_name',
             'Job_name',
             'Method',
@@ -605,15 +632,17 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
             'Date',
             'Status',
             'Last Message',
-        ], $delimiter);
+        ];
+        $sheet->fromArray($headers);
 
         $agent_obj = new Agent();
         $computer  = new Computer();
+        $row       = 2;
 
-        foreach ($data['tasks'] as $task) {
+        foreach ($data['tasks'] ?? [] as $task) {
             $task_name = $task['task_name'] ?? '';
             if (empty($task['jobs'])) {
-                fputcsv($out, [$task_name, '', '', '', '', '', '', '', ''], $delimiter);
+                $sheet->fromArray([$task_name, '', '', '', '', '', '', '', ''], null, 'A' . $row++);
                 continue;
             }
 
@@ -623,13 +652,13 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                 $method   = $job['method'] ?? '';
 
                 if (empty($job['targets'])) {
-                    fputcsv($out, [$task_name, $job_name, $method, '', '', '', '', '', ''], $delimiter);
+                    $sheet->fromArray([$task_name, $job_name, $method, '', '', '', '', '', ''], null, 'A' . $row++);
                 } else {
                     foreach ($job['targets'] as $target) {
                         $target_name = $target['name'] ?? '';
 
                         if (empty($target['agents'])) {
-                            fputcsv($out, [$task_name, $job_name, $method, $target_name, '', '', '', '', ''], $delimiter);
+                            $sheet->fromArray([$task_name, $job_name, $method, $target_name, '', '', '', '', ''], null, 'A' . $row++);
                             continue;
                         }
 
@@ -642,12 +671,12 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                             }
 
                             if (empty($agent)) {
-                                fputcsv($out, [$task_name, $job_name, $method, $target_name, $agent_name, $computer_name, '', '', ''], $delimiter);
+                                $sheet->fromArray([$task_name, $job_name, $method, $target_name, $agent_name, $computer_name, '', '', ''], null, 'A' . $row++);
                                 continue;
                             }
 
                             foreach ($agent as $exec) {
-                                fputcsv($out, [
+                                $sheet->fromArray([
                                     $task_name,
                                     $job_name,
                                     $method,
@@ -657,7 +686,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                                     $exec['last_log_date'] ?? '',
                                     $exec['state'] ?? '',
                                     $exec['last_log'] ?? '',
-                                ], $delimiter);
+                                ], null, 'A' . $row++);
                             }
                         }
                     }
@@ -669,11 +698,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
                 }
             }
         }
-
-        fclose($out);
-
-        // force exit to prevent further display
-        exit; //@phpstan-ignore-line (whole method needs to be refactored)
+        return $spread;
     }
 
 

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -592,89 +592,85 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
         // clean old temporary variables
         unset($task, $job, $target, $agent);
 
-        define('SEP', $CFG_GLPI['csv_delimiter']); // @phpstan-ignore theCodingMachineSafe.function
-        define('NL', "\r\n"); // @phpstan-ignore theCodingMachineSafe.function
+        $delimiter = $CFG_GLPI['csv_delimiter'];
+        $out       = fopen('php://output', 'w');
 
-        // cols titles
-        echo "Task_name" . SEP;
-        echo "Job_name" . SEP;
-        echo "Method" . SEP;
-        echo "Target" . SEP;
-        echo "Agent" . SEP;
-        echo "Computer name" . SEP;
-        echo "Date" . SEP;
-        echo "Status" . SEP;
-        echo "Last Message" . NL;
+        fputcsv($out, [
+            'Task_name',
+            'Job_name',
+            'Method',
+            'Target',
+            'Agent',
+            'Computer name',
+            'Date',
+            'Status',
+            'Last Message',
+        ], $delimiter);
 
         $agent_obj = new Agent();
         $computer  = new Computer();
 
-        // prepare an anonymous (and temporory) function
-        // for test if an element is the last of an array
-        $last = (fn(&$array, $key) => $key === array_key_last($array));
-        foreach ($data['tasks'] as $task_id => $task) {
-            echo $task['task_name'] . SEP;
+        foreach ($data['tasks'] as $task) {
+            $task_name = $task['task_name'] ?? '';
+            if (empty($task['jobs'])) {
+                fputcsv($out, [$task_name, '', '', '', '', '', '', '', ''], $delimiter);
+                continue;
+            }
 
-            if (count($task['jobs']) == 0) {
-                echo NL;
-            } else {
-                $log_cpt = 0;
-                foreach ($task['jobs'] as $job_id => $job) {
-                    echo $job['name'] . SEP;
-                    echo $job['method'] . SEP;
-                    if (count($job['targets']) == 0) {
-                        echo NL;
-                    } else {
-                        foreach ($job['targets'] as $target_id => $target) {
-                            echo $target['name'] . SEP;
+            $log_cpt = 0;
+            foreach ($task['jobs'] as $job) {
+                $job_name = $job['name']   ?? '';
+                $method   = $job['method'] ?? '';
 
-                            if (count($target['agents']) == 0) {
-                                echo NL;
-                            } else {
-                                foreach ($target['agents'] as $agent_id => $agent) {
-                                    $agent_obj->getFromDB($agent_id);
-                                    echo $agent_obj->getName() . SEP;
-                                    $computer->getFromDB($agent_obj->fields['items_id']);
-                                    echo $computer->getname() . SEP;
+                if (empty($job['targets'])) {
+                    fputcsv($out, [$task_name, $job_name, $method, '', '', '', '', '', ''], $delimiter);
+                } else {
+                    foreach ($job['targets'] as $target) {
+                        $target_name = $target['name'] ?? '';
 
-                                    if (count($agent) == 0) {
-                                        echo NL;
-                                    } else {
-                                        foreach ($agent as $exec_id => $exec) {
-                                            echo $exec['last_log_date'] . SEP;
-                                            echo $exec['state'] . SEP;
-                                            echo $exec['last_log'] . NL;
+                        if (empty($target['agents'])) {
+                            fputcsv($out, [$task_name, $job_name, $method, $target_name, '', '', '', '', ''], $delimiter);
+                            continue;
+                        }
 
-                                            if (!$last($agent, $exec_id)) {
-                                                echo SEP . SEP . SEP . SEP . SEP . SEP;
-                                            }
-                                        }
-                                    }
-
-                                    if (!$last($target['agents'], $agent_id)) {
-                                        echo SEP . SEP . SEP . SEP;
-                                    }
-                                }
+                        foreach ($target['agents'] as $agent_id => $agent) {
+                            $agent_obj->getFromDB($agent_id);
+                            $agent_name = $agent_obj->getName();
+                            $computer_name = '';
+                            if (isset($agent_obj->fields['items_id']) && $computer->getFromDB($agent_obj->fields['items_id'])) {
+                                $computer_name = $computer->getName();
                             }
 
-                            if (!$last($job['targets'], $target_id)) {
-                                echo SEP . SEP . SEP;
+                            if (empty($agent)) {
+                                fputcsv($out, [$task_name, $job_name, $method, $target_name, $agent_name, $computer_name, '', '', ''], $delimiter);
+                                continue;
+                            }
+
+                            foreach ($agent as $exec) {
+                                fputcsv($out, [
+                                    $task_name,
+                                    $job_name,
+                                    $method,
+                                    $target_name,
+                                    $agent_name,
+                                    $computer_name,
+                                    $exec['last_log_date'] ?? '',
+                                    $exec['state'] ?? '',
+                                    $exec['last_log'] ?? '',
+                                ], $delimiter);
                             }
                         }
                     }
+                }
 
-                    if (!$last($task['jobs'], $job_id)) {
-                        echo SEP;
-                    }
-
-                    $log_cpt++;
-
-                    if ($includeoldjobs != -1 && $log_cpt >= $includeoldjobs) {
-                        break;
-                    }
+                $log_cpt++;
+                if ($includeoldjobs != -1 && $log_cpt >= $includeoldjobs) {
+                    break;
                 }
             }
         }
+
+        fclose($out);
 
         // force exit to prevent further display
         exit; //@phpstan-ignore-line (whole method needs to be refactored)

--- a/inc/taskview.class.php
+++ b/inc/taskview.class.php
@@ -32,11 +32,10 @@
  */
 
 use Glpi\DBAL\QueryExpression;
-use Safe\DateTime;
-
 use Glpi\Search\Output\SpreadsheetValueBinder;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Csv as CsvWriter;
+use Safe\DateTime;
 
 use function Safe\json_decode;
 use function Safe\json_encode;
@@ -611,7 +610,7 @@ class PluginGlpiinventoryTaskView extends PluginGlpiinventoryCommonView
 
 
     /**
-     * @param array $data
+     * @param array<string, mixed> $data
      * @param int $includeoldjobs
      * @return Spreadsheet
      */

--- a/install/update.php
+++ b/install/update.php
@@ -182,8 +182,6 @@ function pluginGlpiinventoryUpdate(string $current_version): void
     }
 
     $migration = new Migration($current_version);
-    $prepare_task = [];
-    $prepare_rangeip = [];
     $prepare_Config = [];
 
     $a_plugin = plugin_version_glpiinventory();

--- a/tests/Unit/TaskCsvExportTest.php
+++ b/tests/Unit/TaskCsvExportTest.php
@@ -90,13 +90,13 @@ class TaskCsvExportTest extends DbTestCase
         $rows = $this->getRows($this->dataWith([$this->exec('success', 'OK')]));
 
         // Row 0 = headers, row 1 = first execution.
-        $this->assertSame('Test task',           $rows[1][0]);
-        $this->assertSame('Test job',            $rows[1][1]);
-        $this->assertSame('inventory',           $rows[1][2]);
-        $this->assertSame('Test target',         $rows[1][3]);
+        $this->assertSame('Test task', $rows[1][0]);
+        $this->assertSame('Test job', $rows[1][1]);
+        $this->assertSame('inventory', $rows[1][2]);
+        $this->assertSame('Test target', $rows[1][3]);
         $this->assertSame('2026-06-29 16:18:02', $rows[1][6]);
-        $this->assertSame('success',             $rows[1][7]);
-        $this->assertSame('OK',                  $rows[1][8]);
+        $this->assertSame('success', $rows[1][7]);
+        $this->assertSame('OK', $rows[1][8]);
     }
 
     // With several executions, the parent columns must be repeated on every row
@@ -104,13 +104,13 @@ class TaskCsvExportTest extends DbTestCase
     {
         $rows = $this->getRows($this->dataWith([
             $this->exec('success', 'OK'),
-            $this->exec('error',   'KO'),
+            $this->exec('error', 'KO'),
         ]));
 
-        $this->assertSame('Test task',   $rows[2][0]);
-        $this->assertSame('Test job',    $rows[2][1]);
+        $this->assertSame('Test task', $rows[2][0]);
+        $this->assertSame('Test job', $rows[2][1]);
         $this->assertSame('Test target', $rows[2][3]);
-        $this->assertSame('KO',          $rows[2][8]);
+        $this->assertSame('KO', $rows[2][8]);
     }
 
     // a message containing a semicolon,  double quotes or a newline must stay inside a single cell
@@ -119,14 +119,14 @@ class TaskCsvExportTest extends DbTestCase
         $multiline_message = "Line 1\nLine 2 with \"quotes\"\nLine 3;and;semicolons";
 
         $rows = $this->getRows($this->dataWith([
-            $this->exec('error',   'Path not found; aborted'),
+            $this->exec('error', 'Path not found; aborted'),
             $this->exec('success', $multiline_message),
         ]));
 
         // 1 header row + 2 execution rows = 3 rows
         $this->assertCount(3, $rows);
         $this->assertSame('Path not found; aborted', $rows[1][8]);
-        $this->assertSame($multiline_message,        $rows[2][8]);
+        $this->assertSame($multiline_message, $rows[2][8]);
     }
 
     // The $includeoldjobs parameter must cap the number of jobs per task
@@ -154,7 +154,7 @@ class TaskCsvExportTest extends DbTestCase
 
         // 1 header + 2 kept jobs
         $this->assertCount(3, $rows);
-        $this->assertSame('first',  $rows[1][8]);
+        $this->assertSame('first', $rows[1][8]);
         $this->assertSame('second', $rows[2][8]);
     }
 }

--- a/tests/Unit/TaskCsvExportTest.php
+++ b/tests/Unit/TaskCsvExportTest.php
@@ -157,4 +157,44 @@ class TaskCsvExportTest extends DbTestCase
         $this->assertSame('first', $rows[1][8]);
         $this->assertSame('second', $rows[2][8]);
     }
+
+    // Computer  - agent / Columns are populated
+    public function testAgentAndComputerColumnsArePopulated(): void
+    {
+        $computer_id = $this->createItem(Computer::class, [
+            'name'        => 'pc test',
+            'entities_id' => 0,
+        ])->getID();
+
+        // agent requires fk agentType
+        $agenttype_id = $this->createItem(AgentType::class, [
+            'name' => 'type test',
+        ])->getID();
+
+        $agent_id = $this->createItem(Agent::class, [
+            'name'          => 'agent test',
+            'entities_id'   => 0,
+            'itemtype'      => Computer::class,
+            'items_id'      => $computer_id,
+            'deviceid'      => 'deviceid test',
+            'agenttypes_id' => $agenttype_id,
+        ])->getID();
+
+        $data = ['tasks' => [1 => [
+            'task_name' => 'test task',
+            'jobs'      => [10 => [
+                'name'    => 'test job',
+                'method'  => 'inventory',
+                'targets' => [99 => [
+                    'name'   => 'test target',
+                    'agents' => [$agent_id => [$this->exec('success', 'OK')]],
+                ]],
+            ]],
+        ]]];
+
+        $rows = $this->getRows($data);
+
+        $this->assertSame('agent test', $rows[1][4]);
+        $this->assertSame('pc test', $rows[1][5]);
+    }
 }

--- a/tests/Unit/TaskCsvExportTest.php
+++ b/tests/Unit/TaskCsvExportTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * GLPI Inventory Plugin
+ * Copyright (C) 2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on FusionInventory for GLPI
+ * Copyright (C) 2010-2021 by the FusionInventory Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI Inventory Plugin.
+ *
+ * GLPI Inventory Plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI Inventory Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with GLPI Inventory Plugin. If not, see <https://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+use Glpi\Tests\DbTestCase;
+
+class TaskCsvExportTest extends DbTestCase
+{
+    /** @return array<string, string> */
+    private function exec(string $state, string $message): array
+    {
+        return ['last_log_date' => '2026-06-29 16:18:02', 'state' => $state, 'last_log' => $message];
+    }
+
+    // Builds a minimal $data
+    /**
+     * @param array<int, array<string, string>> $execs
+     * @return array<string, mixed>
+     */
+    private function dataWith(array $execs): array
+    {
+        return ['tasks' => [1 => [
+            'task_name' => 'Test task',
+            'jobs'      => [10 => [
+                'name'    => 'Test job',
+                'method'  => 'inventory',
+                'targets' => [99 => [
+                    'name'   => 'Test target',
+                    // agent_id = 0 → Agent::getFromDB() fails, so the name stays empty
+                    'agents' => [0 => $execs],
+                ]],
+            ]],
+        ]]];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<int, array<int|string, mixed>>
+     */
+    private function getRows(array $data, int $includeoldjobs = -1): array
+    {
+        $sheet = (new PluginGlpiinventoryTaskView())
+            ->buildSpreadsheet($data, $includeoldjobs)
+            ->getActiveSheet();
+        return $sheet->toArray(null, true, false);
+    }
+
+    // The header row must be present and well formed
+    public function testHeaders(): void
+    {
+        $rows = $this->getRows(['tasks' => []]);
+        $this->assertSame(
+            ['Task_name', 'Job_name', 'Method', 'Target', 'Agent', 'Computer name', 'Date', 'Status', 'Last Message'],
+            $rows[0]
+        );
+    }
+
+    // A single execution must fill the 9 expected columns
+    public function testSingleExecution(): void
+    {
+        $rows = $this->getRows($this->dataWith([$this->exec('success', 'OK')]));
+
+        // Row 0 = headers, row 1 = first execution.
+        $this->assertSame('Test task',           $rows[1][0]);
+        $this->assertSame('Test job',            $rows[1][1]);
+        $this->assertSame('inventory',           $rows[1][2]);
+        $this->assertSame('Test target',         $rows[1][3]);
+        $this->assertSame('2026-06-29 16:18:02', $rows[1][6]);
+        $this->assertSame('success',             $rows[1][7]);
+        $this->assertSame('OK',                  $rows[1][8]);
+    }
+
+    // With several executions, the parent columns must be repeated on every row
+    public function testParentColumnsRepeated(): void
+    {
+        $rows = $this->getRows($this->dataWith([
+            $this->exec('success', 'OK'),
+            $this->exec('error',   'KO'),
+        ]));
+
+        $this->assertSame('Test task',   $rows[2][0]);
+        $this->assertSame('Test job',    $rows[2][1]);
+        $this->assertSame('Test target', $rows[2][3]);
+        $this->assertSame('KO',          $rows[2][8]);
+    }
+
+    // a message containing a semicolon,  double quotes or a newline must stay inside a single cell
+    public function testMessageWithSpecialCharacters(): void
+    {
+        $multiline_message = "Line 1\nLine 2 with \"quotes\"\nLine 3;and;semicolons";
+
+        $rows = $this->getRows($this->dataWith([
+            $this->exec('error',   'Path not found; aborted'),
+            $this->exec('success', $multiline_message),
+        ]));
+
+        // 1 header row + 2 execution rows = 3 rows
+        $this->assertCount(3, $rows);
+        $this->assertSame('Path not found; aborted', $rows[1][8]);
+        $this->assertSame($multiline_message,        $rows[2][8]);
+    }
+
+    // The $includeoldjobs parameter must cap the number of jobs per task
+    public function testJobCountLimit(): void
+    {
+        $jobWithExec = fn(string $name) => [
+            'name'    => $name,
+            'method'  => 'inventory',
+            'targets' => [99 => [
+                'name'   => 'Target',
+                'agents' => [0 => [$this->exec('success', $name)]],
+            ]],
+        ];
+
+        $data = ['tasks' => [1 => [
+            'task_name' => 'T',
+            'jobs'      => [
+                1 => $jobWithExec('first'),
+                2 => $jobWithExec('second'),
+                3 => $jobWithExec('third'), // must be skipped
+            ],
+        ]]];
+
+        $rows = $this->getRows($data, 2);
+
+        // 1 header + 2 kept jobs
+        $this->assertCount(3, $rows);
+        $this->assertSame('first',  $rows[1][8]);
+        $this->assertSame('second', $rows[2][8]);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44976
- The export used to generate an unusable file: the rows were misaligned, and the "last log" column was generated without proper escaping (semicolons, quotation marks, line breaks, etc.).
We now use phpsreadsheet to ensure compliance and generate the file correctly.

## Screenshots (if appropriate):

