### PR TITLE
Fix install uninstall

### DIFF
--- a/tests/Unit/Deploy/PackageJsonTest.php
+++ b/tests/Unit/Deploy/PackageJsonTest.php
@@ -35,15 +35,9 @@ use Glpi\Tests\DbTestCase;
 
 class PackageJsonTest extends DbTestCase
 {
-    public function setUp(): void
-    {
+    public function setUp(): void {}
 
-    }
-
-    public function tearDown(): void
-    {
-
-    }
+    public function tearDown(): void {}
 
     public function testJsonCreateNewPackage()
     {

--- a/tests/Unit/Deploy/PackageJsonTest.php
+++ b/tests/Unit/Deploy/PackageJsonTest.php
@@ -94,6 +94,15 @@ class PackageJsonTest extends DbTestCase
 
     public function testDuplicate()
     {
+        // purge all packages before test
+        // because addItem test create a package with the same name
+        // and testDuplicate call testAddItem to create a package with the same name
+        $pfDeployPackage = new PluginGlpiinventoryDeployPackage();
+        $packages = $pfDeployPackage->find();
+        foreach ($packages as $package) {
+            $pfDeployPackage->delete(['id' => $package['id']]);
+        }
+
         $this->testAddItem();
         $pfDeployPackage = new PluginGlpiinventoryDeployPackage();
         $packages        = $pfDeployPackage->find(['name' => 'test2_packagejsontest']);

--- a/tests/Unit/Deploy/PackageJsonTest.php
+++ b/tests/Unit/Deploy/PackageJsonTest.php
@@ -71,7 +71,7 @@ class PackageJsonTest extends DbTestCase
     {
         $pfDeployPackage = new PluginGlpiinventoryDeployPackage();
         $input = [
-            'name'        => 'test2',
+            'name'        => 'test2_packagejsontest',
             'entities_id' => 0,
         ];
         $packages_id = $pfDeployPackage->add($input);
@@ -97,13 +97,13 @@ class PackageJsonTest extends DbTestCase
     {
         $this->testAddItem();
         $pfDeployPackage = new PluginGlpiinventoryDeployPackage();
-        $packages        = $pfDeployPackage->find(['name' => 'test2']);
+        $packages        = $pfDeployPackage->find(['name' => 'test2_packagejsontest']);
         $this->assertEquals(1, count($packages));
         $package = current($packages);
 
         $this->assertTrue($pfDeployPackage->duplicate($package['id']));
 
-        $packages = $pfDeployPackage->find(['name' => 'Copy of test2']);
+        $packages = $pfDeployPackage->find(['name' => 'Copy of test2_packagejsontest']);
         $this->assertEquals(1, count($packages));
         $package = current($packages);
 

--- a/tests/Unit/Deploy/PackageJsonTest.php
+++ b/tests/Unit/Deploy/PackageJsonTest.php
@@ -35,6 +35,16 @@ use Glpi\Tests\DbTestCase;
 
 class PackageJsonTest extends DbTestCase
 {
+    public function setUp(): void
+    {
+
+    }
+
+    public function tearDown(): void
+    {
+
+    }
+
     public function testJsonCreateNewPackage()
     {
         $pfDeployPackage = new PluginGlpiinventoryDeployPackage();

--- a/tests/Unit/Deploy/PackageJsonTest.php
+++ b/tests/Unit/Deploy/PackageJsonTest.php
@@ -32,12 +32,24 @@
  */
 
 use Glpi\Tests\DbTestCase;
+use Glpi\Tests\GLPITestCase;
 
 class PackageJsonTest extends DbTestCase
 {
-    public function setUp(): void {}
 
-    public function tearDown(): void {}
+    public function setUp(): void
+    {
+        GLPITestCase::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        global $DB;
+
+        $DB->setMustUnsanitizeData(false); // Be sure to switch back to disabled unsanitization.
+
+        GLPITestCase::tearDown();
+    }
 
     public function testJsonCreateNewPackage()
     {

--- a/tests/Unit/Deploy/PackageJsonTest.php
+++ b/tests/Unit/Deploy/PackageJsonTest.php
@@ -36,7 +36,6 @@ use Glpi\Tests\GLPITestCase;
 
 class PackageJsonTest extends DbTestCase
 {
-
     public function setUp(): void
     {
         GLPITestCase::setUp();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Since the changes introduced in https://github.com/glpi-project/glpi/pull/24271, some plugins may expose an incorrect use of `beginTransaction()`.

During plugin installation, database tables are created. DDL operations such as table creation cannot reliably be executed within a transaction, making the use of `beginTransaction()` in this context invalid.

Fix CI failed for

https://github.com/glpi-project/glpi-inventory-plugin/actions/runs/28504827982/job/84490610221?pr=964

## Screenshots (if appropriate):
