### PR TITLE
Domain search criteria fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix task execution results CSV export
 - Add column log status in CSV export
+- Allow `domain` READ right for dynamic group criterion
 
 ## [1.6.8] - 2026-06-24
 

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -350,6 +350,7 @@ class PluginGlpiinventoryToolbox
         $_SESSION['glpiactiveprofile']['interface'] = 'central';
 
         $_SESSION["glpiactiveprofile"]["computer"] = 1;
+        $_SESSION["glpiactiveprofile"]["domain"] = 1;
 
         // Execute function with impersonated SESSION
         $result = call_user_func_array($function, $args);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.


- fixes : #972 

## Description

The `DOMAIN` criterion requires a specific permission to be available.

```php
if (in_array($itemtype, Domain::getTypes(true))) {
    if (Session::haveRight("domain", READ)) { // HERE
        // Search option
    }
}
```

By default, a user only has the **Self-Service** profile, which does not grant the `READ` permission on **Domain** objects. As a result, the `DOMAIN` criterion is not available when agent call GLPI.

To make this criterion available to Self-Service users, the `READ` permission on `Domain` should be granted.

## Screenshots (if appropriate):
