### PR TITLE
fix(collect): handle REG_MULTI_SZ and hex DWORDs consistently

### DIFF
--- a/inc/collect_registry_content.class.php
+++ b/inc/collect_registry_content.class.php
@@ -111,9 +111,17 @@ class PluginGlpiinventoryCollect_Registry_Content extends PluginGlpiinventoryCol
         }
 
         unset($registry_data['_sid']);
+        foreach ($registry_data as $k => $v) {
+            if (is_array($v)) {
+                $registry_data[$k] = implode("\n", $v);
+            }
+        }
         foreach ($registry_data as $key => $value) {
             foreach ($db_registries as $keydb => $arraydb) {
                 if ($arraydb['key'] == $key) {
+                    if (preg_match("/^0x[0-9a-fA-F]{1,}$/", $value)) {
+                        $value = hexdec($value);
+                    }
                     $input = ['key'   => $arraydb['key'],
                         'id'    => $keydb,
                         'value' => $value,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

updateComputer() receives the agent's registry data and treats it as
scalar strings on both its update and insert paths. Two value types
break that assumption.

A REG_MULTI_SZ value is decoded by the agent as a list, so $value is an
array. The insert path calls preg_match() on it and raises

  TypeError: Safe\preg_match(): Argument #2 ($subject) must be of type
  string, array given, called in collect_registry_content.class.php:134

which is uncaught, so the endpoint answers 500 and the agent discards
its whole submission. Agent-side this appears as "Bad answer: CSRF
checking is failing", which is misleading: no CSRF check is involved and
nothing is written to GLPI's access-errors.log. The update path fails
silently instead, storing the literal string "Array". One multi-string
in a collected key is enough to lose every other value in that Collect.

A REG_DWORD arrives as a hex string. The insert path converts it with
hexdec(), the update path does not, so a value is decimal on its first
harvest and "0x0000002D" on every harvest after. A consumer casting that
to int gets 0, and cannot tell the two encodings apart.

Both are fixed where the data enters: multi-strings are joined once,
immediately after _sid is removed, which covers both paths, and the
existing hex conversion is applied on the update path too.

Tested on GLPI 11.0.8, GLPI Inventory 1.6.8, GLPI Agent 1.18, Windows
hosts, with a Collect of seven keys mixing REG_SZ, REG_DWORD and
REG_MULTI_SZ values. Before: four keys returned nothing and the task
reported an error. After: all keys harvest and values store decimal.

## Screenshots (if appropriate):
