### PR TITLE
Fix: harmonize rights check on deploy package content edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Harmonize rights check when editing a deploy package's actions, files or checks
 - Harden value encoding in action/definition dropdown selection scripts
 - Remove unused XML message setter in communication class
 - Harmonize rights checks across collect, deploy, task, IP range and agent module management entry points

--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -30,6 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Safe\Exceptions\JsonException;
 
@@ -702,6 +703,12 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
      */
     public static function alterJSON(string $action_type, array $params): bool
     {
+        $packages_id = $params['id'] ?? $params['packages_id'] ?? 0;
+        $package     = new self();
+        if (!$package->getFromDB($packages_id) || !$package->canUpdateContent()) {
+            throw new AccessDeniedHttpException('Missing right to update this package content');
+        }
+
         //route to sub class
         $item_type = $params['itemtype'];
 
@@ -981,6 +988,10 @@ class PluginGlpiinventoryDeployPackage extends CommonDBTM
     public static function updateOrderJson($packages_id, $datas)
     {
         $pfDeployPackage = new self();
+        if (!$pfDeployPackage->getFromDB($packages_id) || !$pfDeployPackage->canUpdateContent()) {
+            throw new AccessDeniedHttpException('Missing right to update this package content');
+        }
+
         $options = JSON_UNESCAPED_SLASHES;
 
         $json = \json_encode($datas, $options); // @phpstan-ignore theCodingMachineSafe.function (error are properly checked here)

--- a/tests/Integration/Deploy/RepositoryTest.php
+++ b/tests/Integration/Deploy/RepositoryTest.php
@@ -42,6 +42,8 @@ class RepositoryTest extends DbTestCase
     public function setUp(): void
     {
         parent::setUp();
+        $this->login('glpi', 'glpi');
+
         $pfDeployPackage = new PluginGlpiinventoryDeployPackage();
 
         // create a package

--- a/tests/Unit/Deploy/PackageJsonTest.php
+++ b/tests/Unit/Deploy/PackageJsonTest.php
@@ -67,6 +67,8 @@ class PackageJsonTest extends DbTestCase
 
     public function testAddItem()
     {
+        $this->login('glpi', 'glpi');
+
         $pfDeployPackage = new PluginGlpiinventoryDeployPackage();
         $input = [
             'name'        => 'test2_packagejsontest',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- Rights checks on deploy package content edition (actions, files, checks) were inconsistent across entry points.
- All entry points now rely on the same rights check already used for the package edition UI.

## Screenshots (if appropriate):
