### PR TITLE
Fix: restore agent modules left join in computer search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Restore agent modules left join in computer search
 - Harmonize rights check when editing a deploy package's actions, files or checks
 - Harden value encoding in action/definition dropdown selection scripts
 - Remove unused XML message setter in communication class

--- a/hook.php
+++ b/hook.php
@@ -543,11 +543,15 @@ function plugin_glpiinventory_addLeftJoin(
             $a_agent_modules = PluginGlpiinventoryAgentmodule::getModules();
             foreach ($a_agent_modules as $module) {
                 if ($new_table . "." . $linkfield == 'glpi_plugin_glpiinventory_agentmodules.' . $module) {
-                    return " LEFT JOIN `glpi_plugin_glpiinventory_agentmodules` AS `FUSION_" . $module . "`"
-                          . " ON `FUSION_" . $module . "`.`modulename`='" . $module . "'"
-                          . " LEFT JOIN `glpi_agents` AS `agent" . strtolower($module) . "`"
-                          . " ON (`glpi_computers`.`id`=`agent" . strtolower($module) . "`.`items_id`"
-                          . " AND `agent" . strtolower($module) . "`.`itemtype`='Computer') ";
+                    $agent_alias = "agent" . strtolower($module);
+                    // GLPI parses this string (see SQLProvider::parseJoinString()) with a regex that
+                    // stops on end of lines: the `ON` keyword must start a new line, and the whole
+                    // join condition must fit on a single line.
+                    return " LEFT JOIN `glpi_plugin_glpiinventory_agentmodules` AS `FUSION_" . $module . "`\n"
+                          . " ON `FUSION_" . $module . "`.`modulename`='" . $module . "'\n"
+                          . " LEFT JOIN `glpi_agents` AS `" . $agent_alias . "`\n"
+                          . " ON (`glpi_computers`.`id`=`" . $agent_alias . "`.`items_id`"
+                          . " AND `" . $agent_alias . "`.`itemtype`='Computer')";
                 }
             }
             break;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45767
- Here is a brief description of what this PR does
Fixes an SQL error (1064) in asset lists when a plugin adds a column via the addSelect hook: the comma separator returned by the hook was no longer removed, resulting in a duplicate comma in the query.

## Screenshots (if appropriate):
