### PR TITLE
Remove "non existing" Safe function

### DIFF
--- a/inc/deployfile.class.php
+++ b/inc/deployfile.class.php
@@ -45,7 +45,6 @@ use function Safe\fwrite;
 use function Safe\gzclose;
 use function Safe\gzopen;
 use function Safe\gzwrite;
-use function Safe\hash_file;
 use function Safe\ini_get;
 use function Safe\json_decode;
 use function Safe\json_encode;
@@ -786,7 +785,7 @@ class PluginGlpiinventoryDeployFile extends PluginGlpiinventoryDeployPackageItem
      */
     public function registerFilepart($filePath, $skip_creation = false)
     {
-        $sha512 = hash_file('sha512', $filePath);
+        $sha512 = hash_file('sha512', $filePath); //@phpstan-ignore theCodingMachineSafe.function (see https://github.com/glpi-project/glpi-inventory-plugin/issues/981)
 
         if (!$skip_creation) {
             $dir = PLUGIN_GLPI_INVENTORY_REPOSITORY_DIR . $this->getDirBySha512($sha512);
@@ -812,7 +811,7 @@ class PluginGlpiinventoryDeployFile extends PluginGlpiinventoryDeployPackageItem
         $file_tmp_name = $params['file_tmp_name'];
         $maxPartSize   = 1024 * 1024;
         $tmpFilepart   = tempnam(GLPI_PLUGIN_DOC_DIR . "/glpiinventory/", "filestore");
-        $sha512        = hash_file('sha512', $file_tmp_name);
+        $sha512        = hash_file('sha512', $file_tmp_name); //@phpstan-ignore theCodingMachineSafe.function (see https://github.com/glpi-project/glpi-inventory-plugin/issues/981)
         $short_sha512  = substr($sha512, 0, 6);
 
         $file_present_in_repo = false;

--- a/install/update.php
+++ b/install/update.php
@@ -49,7 +49,6 @@ use function Safe\mkdir;
 use function Safe\preg_match;
 use function Safe\preg_replace;
 use function Safe\rename;
-use function Safe\unserialize;
 
 include_once(PLUGIN_GLPI_INVENTORY_DIR . "/install/update.tasks.php");
 /**
@@ -5594,7 +5593,7 @@ function do_computeroperatingsystem_migration(Migration $migration): void
                 // else try unserialize
                 $from_serialize = true;
                 try {
-                    $unserialized = @unserialize($fields_array, ['allowed_classes' => false]);
+                    $unserialized = @unserialize($fields_array, ['allowed_classes' => false]); //@phpstan-ignore theCodingMachineSafe.function (see https://github.com/glpi-project/glpi-inventory-plugin/issues/981)
 
                     if ($unserialized !== false) {
                         $fields = $unserialized;
@@ -7177,7 +7176,7 @@ function migrationDynamicGroupFields(string $fields): string
             $data = $decoded;
         }
     } else {
-        $unserialized = @unserialize($fields, ['allowed_classes' => false]);
+        $unserialized = @unserialize($fields, ['allowed_classes' => false]); //@phpstan-ignore theCodingMachineSafe.function (see https://github.com/glpi-project/glpi-inventory-plugin/issues/981)
         $from_serialized = true;
         if ($unserialized !== false) {
             $data = $unserialized;


### PR DESCRIPTION
closes #981

I'm not able to reproduce the issue.
As far as I can see in the lib code, this should be available for all supported PHP versions.
